### PR TITLE
# Improve UI/UX

### DIFF
--- a/src/components/AccountView.jsx
+++ b/src/components/AccountView.jsx
@@ -15,7 +15,6 @@ const AccountView = ({ t, fields, passphrase, isFetching, onFieldChange, onPassp
     <h2>{t('AccountView.title')}</h2>
     <Input name='email' type='email' {...fields.email} onChange={onFieldChange} />
     <Input name='public_name' type='text' {...fields.public_name} onChange={onFieldChange} />
-    <PassphraseForm {...passphrase} onSubmit={onPassphraseSubmit} />
     <Select name='locale' options={LANG_OPTIONS} {...fields.locale} onChange={onFieldChange} />
     <p className={styles['account-view-desc']}>
       <ReactMarkdown
@@ -25,6 +24,7 @@ const AccountView = ({ t, fields, passphrase, isFetching, onFieldChange, onPassp
         renderers={{Link: props => <a href={props.href} target='_blank'>{props.children}</a>}}
       />
     </p>
+    <PassphraseForm {...passphrase} onSubmit={onPassphraseSubmit} />
   </div>
 )
 

--- a/src/components/PassphraseForm.jsx
+++ b/src/components/PassphraseForm.jsx
@@ -67,20 +67,20 @@ class PassphraseForm extends Component {
         />
         {errors.newPassword && <p className={styles['coz-errors']}>{t(errors.newPassword)}</p>}
         {errors.global && <p className={styles['coz-errors']}>{t(errors.global)}</p>}
-        <a href='#' className={styles['password-reset-link']}>
-          {t('AccountView.password.reset_link')}
-        </a>
         <div className={styles['coz-form-controls']}>
           <button
             role='button'
-            className={styles['primary']}
+            className={styles['secondary']}
             aria-busy={submitting ? 'true' : 'false'}
             onClick={e => this.handleSubmit(e)}
             disabled={!canSubmit}
           >
-            Save
+            {t('AccountView.password.submit_label')}
           </button>
         </div>
+        <a href='#' className={styles['password-reset-link']}>
+          {t('AccountView.password.reset_link')}
+        </a>
       </div>
     )
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,7 +16,8 @@
       "password_too_weak": "Your password is too weak. You should add an uppercase, a number, a special character or a longer password.",
       "wrong_password": "Current password seems wrong.",
       "success": "Your password has been changed",
-      "reset_link": "Forgot your current password?"
+      "reset_link": "Forgot your current password?",
+      "submit_label": "Change your password"
     },
     "current_password": {
       "label": "Enter your current password",

--- a/src/styles/fields.styl
+++ b/src/styles/fields.styl
@@ -18,6 +18,15 @@
     .password-reset-link
         margin-top      .5em
 
+    .coz-form-controls
+        padding 0
+        margin  1em 0
+        width   100%
+
+        [role=button]
+            margin-left 0
+            margin-right 0
+
     .set-field
         &:after
             opacity 0

--- a/src/styles/fields.styl
+++ b/src/styles/fields.styl
@@ -16,15 +16,15 @@
         font-weight     bold
 
     .password-reset-link
-        margin-top      .5em
+        margin-top .5em
 
     .coz-form-controls
-        padding 0
         margin  1em 0
         width   100%
+        padding 0
 
         [role=button]
-            margin-left 0
+            margin-left  0
             margin-right 0
 
     .set-field


### PR DESCRIPTION
The main goal is to avoid the feeling that the _save_ button's role is to save the whole form. To achieve that, we can:

 * Switch locale and password position, to put password at the end and to not have a button in the middle of the form.
 * Change the button label to make it more explicit
 * Avoid to center the button, we may make its width to be 100%
 * Use a secondary button instead as a primary one, as the submit action does not submit the whole form
 * Switch position between button and _Forgot your passphrase_ link, to make the button more related to the old/new passphrases fieds

![capture d ecran 2017-02-10 a 19 06 20](https://cloud.githubusercontent.com/assets/776764/22838140/0fcd9fe6-efc4-11e6-8f8a-2652e69eea9a.png)

(with @kelukelu seal of approval)