### PR TITLE
[fix] Inject cozy bar with the stack

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{.Locale}}">
 <meta charset="utf-8">
 <title><%= htmlWebpackPlugin.options.title %></title>
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -14,4 +14,13 @@
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>" defer></script>
 <% }); %>
-<div role="application">
+{{.CozyClientJS}}
+{{.CozyBar}}
+<div
+  role="application"
+  data-cozy-token="{{.Token}}"
+  data-cozy-domain="{{.Domain}}"
+  data-cozy-locale="{{.Locale}}"
+  data-cozy-app-name="{{.AppName}}"
+  data-cozy-icon-path="{{.IconPath}}"
+>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+/* global cozy */
 import 'babel-polyfill'
 
 import './styles/main'

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,8 +2,6 @@ import 'babel-polyfill'
 
 import './styles/main'
 
-import cozy from 'cozy-bar'
-
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider, connect } from 'react-redux'
@@ -21,10 +19,6 @@ import { fetchInfos } from './actions'
 
 import App from './components/App'
 import Account from './containers/Account'
-
-cozy.bar.init({
-  appName: 'Settings'
-})
 
 const loggerMiddleware = createLogger()
 
@@ -69,6 +63,15 @@ const ConnectedI18nProvider = connect(state => {
 })(I18nProvider)
 
 document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('[role=application]')
+  const data = root.dataset
+
+  cozy.bar.init({
+    appName: data.cozyAppName,
+    iconPath: data.cozyIconPath,
+    lang: data.cozyLocale
+  })
+
   render((
     <Provider store={store}>
       <ConnectedI18nProvider>
@@ -102,5 +105,5 @@ document.addEventListener('DOMContentLoaded', () => {
         </Router>
       </ConnectedI18nProvider>
     </Provider>
-  ), document.querySelector('[role=application]'))
+  ), root)
 })


### PR DESCRIPTION
Settings was still using the "old" way to include the cozy-bar and cozy-client-js, so things were a bit broken. This patch only fixes the bar, I'll submit a separate patch to use cozy-client-js if this one is ok.

@m4dz Aside from the changes included, is there anything in the webpack build process that I should change? Or something else I forgot?