### PR TITLE
Translations fixes

### DIFF
--- a/src/components/ProfileView.jsx
+++ b/src/components/ProfileView.jsx
@@ -19,7 +19,7 @@ const ProfileView = ({ t, fields, passphrase, isFetching, onFieldChange, onPassp
     <p className={styles['profile-view-desc']}>
       <ReactMarkdown
         source={
-          t(`ProfileView.locale.contrib`)
+          t('ProfileView.locale.contrib', {link: 'https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937'})
         }
         renderers={{Link: props => <a href={props.href} target='_blank'>{props.children}</a>}}
       />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,7 +3,7 @@
     "profile": "Profile",
     "connected_devices": "Connected devices",
     "storage": "Storage",
-    "email_notifications": "Email notifications"
+    "email_notifications": "E-mail notifications"
   },
   "Loading": {
     "loading": "Loading"
@@ -41,9 +41,9 @@
       "empty": "This field cannot be empty"
     },
     "email" : {
-      "title" : "Email",
-      "label": "Cozy needs your email to send you notifications and allow you to recover your password",
-      "error" : "The email address does not feel right. Are you sure you wrote it correctly (e.g. john@wayne.com)?"
+      "title" : "E-mail",
+      "label": "Cozy needs your e-mail to send you notifications and allow you to recover your password",
+      "error" : "The e-mail address does not feel right. Are you sure you wrote it correctly (e.g. john@wayne.com)?"
     },
     "public_name" : {
       "title" : "Username",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,7 +52,7 @@
     "locale" : {
       "title" : "Language",
       "label": "This will be the language used in your Cozy.",
-      "contrib" : "Interested in helping translate Cozy? [Check out how you can **give us a hand** on that](https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937).",
+      "contrib" : "Interested in helping translate Cozy? [Check out how you can **give us a hand** on that](%{link}).",
       "en" : {
         "text" : "English"
       },


### PR DESCRIPTION
This PR:

- fixes a typo in _e-mail_ translation in **en** source locale (we write _e-mail_, not _email_)
- avoid links in translation. To prevent errors or malicious links injections in locales, we only pass variables to the markdown content and interpolate them w/ polyglot