### PR TITLE
 Application install/update screen implementation (SET-11) 

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -30,7 +30,7 @@
     "apps": {
       "description": "Required by the cozy-bar to display the icons of the apps",
       "type": "io.cozy.apps",
-      "verbs": ["GET"]
+      "verbs": ["GET", "POST", "PUT"]
     }
   },
   "routes": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -161,7 +161,7 @@ export const deviceModaleRevokeClose = () => ({
 export const installApp = (slug, repourl, isupdate) => {
   return (dispatch, getState) => {
     dispatch({ type: INSTALL_APP })
-    let verb = isupdate ? 'PUT' : 'POST'
+    const verb = isupdate ? 'PUT' : 'POST'
     return cozyFetch(verb, `/apps/${slug}?Source=${encodeURIComponent(repourl)}`)
     .then(response => {
       dispatch({
@@ -212,7 +212,7 @@ const cozyFetch = (method, path, body) => {
         data = response.text()
       }
 
-      return (response.status >= 200 && response.status < 300)
+      return (response.status === 200 || response.status === 202 || response.status === 204)
         ? data
         : data.then(Promise.reject.bind(Promise))
     })

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,6 +23,9 @@ export const DEVICE_REVOKE = 'DEVICE_REVOKE'
 export const DEVICE_REVOKE_SUCCESS = 'DEVICE_REVOKE_SUCCESS'
 export const DEVICE_REVOKE_FAILURE = 'DEVICE_REVOKE_FAILURE'
 export const ALERT_CLOSED = 'ALERT_CLOSED'
+export const INSTALL_APP = 'INSTALL_APP'
+export const INSTALL_APP_SUCCESS = 'INSTALL_APP_SUCCESS'
+export const INSTALL_APP_FAILURE = 'INSTALL_APP_FAILURE'
 
 export const fetchInfos = () => {
   return (dispatch, getState) => {
@@ -155,6 +158,34 @@ export const deviceModaleRevokeClose = () => ({
   type: DEVICES_MODALE_REVOKE_CLOSE
 })
 
+export const installApp = (slug, repourl, isupdate) => {
+  return (dispatch, getState) => {
+    dispatch({ type: INSTALL_APP })
+    let verb = isupdate ? 'PUT' : 'POST'
+    return cozyFetch(verb, `/apps/${slug}?Source=${encodeURIComponent(repourl)}`)
+    .then(response => {
+      dispatch({
+        type: INSTALL_APP_SUCCESS,
+        alert: {
+          message: `InstallView.${isupdate ? 'update' : 'install'}_success`,
+          messageData: {slug},
+          level: 'success'
+        }
+      })
+    })
+    .catch(() => {
+      dispatch({
+        type: INSTALL_APP_FAILURE,
+        alert: {
+          message: `InstallView.${isupdate ? 'update' : 'install'}_error`,
+          messageData: {slug},
+          level: 'error'
+        }
+      })
+    })
+  }
+}
+
 const STACK_DOMAIN = '//' + document.querySelector('[role=application]').dataset.cozyDomain
 const STACK_TOKEN = document.querySelector('[role=application]').dataset.cozyToken
 
@@ -181,7 +212,7 @@ const cozyFetch = (method, path, body) => {
         data = response.text()
       }
 
-      return (response.status === 200 || response.status === 204)
+      return (response.status >= 200 && response.status < 300)
         ? data
         : data.then(Promise.reject.bind(Promise))
     })

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -5,12 +5,13 @@ import { translate } from 'cozy-ui/react/helpers/i18n'
 import withState from 'cozy-ui/react/helpers/withState'
 import Field from './Field'
 
-const Input = ({ t, name, type = 'text', value, submitting, errors, onChange }) => (
+const Input = ({ t, name, type = 'text', placeholder = '', value, submitting, errors, onChange }) => (
   <input
     type={type}
+    placeholder={placeholder}
     value={value}
     name={name}
-    onBlur={e => onChange(name, e.target.value)}
+    onBlur={e => onChange(name, e.target.type === 'checkbox' ? e.target.checked : e.target.value)}
     className={errors && errors.length !== 0 ? styles['error'] : ''}
     aria-busy={submitting}
   />

--- a/src/components/InstallerView.jsx
+++ b/src/components/InstallerView.jsx
@@ -1,27 +1,61 @@
+import styles from '../styles/fields'
 import viewStyles from '../styles/view'
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/helpers/i18n'
 import classNames from 'classnames'
+import Input from './Input'
 
 class InstallerView extends Component {
-  doInstall () {
-    // get the values from the fields
-    const slug = document.querySelector('#slug').value
-    const repourl = document.querySelector('#repourl').value
-    const isupdate = document.querySelector('#isupdate').checked
-    this.onSubmit(slug, repourl, isupdate)
+  constructor (props) {
+    super(props)
+    this.state = {
+      slug: null,
+      url: null,
+      isUpdate: false
+    }
   }
 
-  render ({t, onSubmit}) {
-    this.onSubmit = onSubmit
+  onChange (name, value) {
+    this.state[name] = value
+  }
+
+  handleSubmit () {
+    this.props.onSubmit(this.state.slug, this.state.url, this.state.isUpdate)
+  }
+
+  render ({t, onSubmit, slug, url}) {
     return (
       <div role='contentinfo'>
         <div className={classNames(viewStyles['set-view-content'], viewStyles['set-view-content--narrow'])}>
           <h2 className={viewStyles['set-view-title']}>{t('InstallView.title')}</h2>
-          <input id='slug' placeholder='slug' /><br />
-          <label>{t('InstallView.update')}</label> <input id='isupdate' type='checkbox' />
-          <input id='repourl' value='git://github.com/username/repository.git#branch' />
-          <button onclick={this.doInstall.bind(this)}>{t('InstallView.submit')}</button>
+          <div className={styles['coz-form']}>
+            <Input
+              onChange={this.onChange.bind(this)}
+              label={t('InstallView.repository_url')}
+              placeholder='git://github.com/username/repository.git#branch'
+              name='url'
+            />
+            <Input
+              onChange={this.onChange.bind(this)}
+              label={t('InstallView.slug')}
+              name='slug'
+            />
+            <Input
+              onChange={this.onChange.bind(this)}
+              type='checkbox'
+              label={t('InstallView.update')}
+              name='isUpdate'
+            />
+            <div className={styles['coz-form-controls']}>
+              <button
+                role='button'
+                className={classNames('coz-btn', 'coz-btn--regular')}
+                onClick={this.handleSubmit.bind(this)}
+              >
+                {t('InstallView.submit')}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     )

--- a/src/components/InstallerView.jsx
+++ b/src/components/InstallerView.jsx
@@ -1,0 +1,31 @@
+import viewStyles from '../styles/view'
+import React, { Component } from 'react'
+import { translate } from 'cozy-ui/react/helpers/i18n'
+import classNames from 'classnames'
+
+class InstallerView extends Component {
+  doInstall () {
+    // get the values from the fields
+    const slug = document.querySelector('#slug').value
+    const repourl = document.querySelector('#repourl').value
+    const isupdate = document.querySelector('#isupdate').checked
+    this.onSubmit(slug, repourl, isupdate)
+  }
+
+  render ({t, onSubmit}) {
+    this.onSubmit = onSubmit
+    return (
+      <div role='contentinfo'>
+        <div className={classNames(viewStyles['set-view-content'], viewStyles['set-view-content--narrow'])}>
+          <h2 className={viewStyles['set-view-title']}>{t('InstallView.title')}</h2>
+          <input id='slug' placeholder='slug' /><br />
+          <label>{t('InstallView.update')}</label> <input id='isupdate' type='checkbox' />
+          <input id='repourl' value='git://github.com/username/repository.git#branch' />
+          <button onclick={this.doInstall.bind(this)}>{t('InstallView.submit')}</button>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default translate()(InstallerView)

--- a/src/containers/Installer.jsx
+++ b/src/containers/Installer.jsx
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux'
+
+import InstallerView from '../components/InstallerView'
+import { installApp } from '../actions'
+
+const mapStateToProps = (state, ownProps) => ({
+  slug: state.slug,
+  appUrl: state.appUrl
+})
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  onSubmit: (slug, appUrl, isUpdate) => {
+    return dispatch(installApp(slug, appUrl, isUpdate))
+  }
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(InstallerView)

--- a/src/containers/Installer.jsx
+++ b/src/containers/Installer.jsx
@@ -3,15 +3,10 @@ import { connect } from 'react-redux'
 import InstallerView from '../components/InstallerView'
 import { installApp } from '../actions'
 
-const mapStateToProps = (state, ownProps) => ({
-  slug: state.slug,
-  appUrl: state.appUrl
-})
+const mapStateToProps = (state, ownProps) => ({})
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  onSubmit: (slug, appUrl, isUpdate) => {
-    return dispatch(installApp(slug, appUrl, isUpdate))
-  }
+  onSubmit: (slug, appUrl, isUpdate) => dispatch(installApp(slug, appUrl, isUpdate))
 })
 
 export default connect(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,7 +88,7 @@
     "update_success": "%{slug} is updating",
     "update": "Update",
     "slug": "Slug",
-    "Repository_url": "Repository url",
+    "repository_url": "Repository url",
     "submit": "Submit"
   },
   "ServicesView": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,6 +80,17 @@
     "validate": "Revoke device",
     "error": "Unable to revoke the device, try to reload the page."
   },
+  "InstallView": {
+    "title": "Application installation",
+    "install_error": "An error occured while installing %{slug}",
+    "update_error": "An error occured while updating %{slug}",
+    "install_success": "%{slug} is installing",
+    "update_success": "%{slug} is updating",
+    "update": "Update",
+    "slug": "Slug",
+    "Repository_url": "Repository url",
+    "submit": "Submit"
+  },
   "ServicesView": {
     "title": "Activated services",
     "load_error": "An error occured while loading your services, please try again later.",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -23,6 +23,7 @@ import App from './components/App'
 import Profile from './containers/Profile'
 import Services from './containers/Services'
 import Devices from './containers/Devices'
+import Installer from './containers/Installer'
 
 const loggerMiddleware = createLogger()
 
@@ -111,6 +112,10 @@ document.addEventListener('DOMContentLoaded', () => {
               path='connectedDevices'
               component={Devices}
               onEnter={() => store.dispatch(fetchDevices())}
+            />
+            <Route
+              path='install'
+              component={Installer}
             />
             <Route
               path='storage'


### PR DESCRIPTION
Here is a second (see #36 ) implementation of the hidden application install/update screen.

This hidden screen is accessible with the following url : http://settings.cozy.local:8080/#/install

It is important that the settings application has the "settings" slug or else the stack will refuse any application install/update.

And it is also important that the cozy-stack is updated (at the moment, the docker image does not work)