### PR TITLE
feat: Add Support for editor's name

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,6 +4,7 @@
   "icon": "app-icon.svg",
   "description": "Settings manager for Cozy v3",
   "source": "https://github.com/cozy/cozy-settings.git@build",
+  "editor": "Cozy",
   "developer": {
     "name": "Cozy",
     "url": "https://cozy.io"

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -24,5 +24,6 @@
   data-cozy-domain="{{.Domain}}"
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
+  data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -88,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cozy.bar.init({
     appName: data.cozyAppName,
+    appEditor: data.cozyAppEditor,
     iconPath: data.cozyIconPath,
     lang: data.cozyLocale
   })


### PR DESCRIPTION
Adding Editor's name to the manifest so the stack can use it and make sure this data is shared so the cozy-bar can use it.

tl;dr: It displays the "Cozy" before the "Drive" in the Cozy-bar

Related PR: https://github.com/cozy/cozy-bar/pull/37
