### PR TITLE
Specify the jobs permissions

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -40,7 +40,10 @@
     },
     "jobs": {
       "description": "Required to send emails to support",
-      "type": "io.cozy.jobs"
+      "type": "io.cozy.jobs",
+      "verbs": ["POST"],
+      "selector": "worker",
+      "values": ["sendmail"]
     }
   },
   "routes": {


### PR DESCRIPTION
Specify the jobs permissions to explicitly ask for the `sendmail` worker. This evolution is required by this change in cozy-stack: https://github.com/cozy/cozy-stack/pull/950