### PR TITLE
Add offers button if offers link are available

### DIFF
--- a/src/components/StorageView.jsx
+++ b/src/components/StorageView.jsx
@@ -1,4 +1,5 @@
-import styles from '../styles/view'
+import viewStyles from '../styles/view'
+import styles from '../styles/storage'
 
 import React, { Component } from 'react'
 
@@ -6,6 +7,7 @@ import classNames from 'classnames'
 import Loading from './Loading'
 
 import { translate } from 'cozy-ui/react/I18n'
+import { ButtonLink } from 'cozy-ui/react/Button'
 
 class StorageView extends Component {
   componentWillMount () {
@@ -22,11 +24,11 @@ class StorageView extends Component {
       : storageData.usage
     const percent = diskUsage / diskQuota * 100
     return (
-      <div role='contentinfo'>
-        <h2 className={styles['set-view-title']}>
+      <div className={classNames(viewStyles['set-view-content'], viewStyles['set-view-content--narrow'])}>
+        <h2 className={viewStyles['set-view-title']}>
           {t('StorageView.title')}
         </h2>
-        <h3 className={styles['set-view-subtitle']}>
+        <h3 className={viewStyles['set-view-subtitle']}>
           {t('StorageView.storage_title')}
         </h3>
         {isFetching && <Loading />}
@@ -34,7 +36,7 @@ class StorageView extends Component {
           storageData && (
             <div>
               <h2
-                className={styles['set-view-title']}
+                className={viewStyles['set-view-title']}
               >{t('StorageView.storage_phrase', {
                 diskUsage,
                 diskQuota
@@ -49,6 +51,21 @@ class StorageView extends Component {
               >
                 {`${percent}%`}
               </span>
+              {storageData.offersLink &&
+                <div>
+                  <h3 className={viewStyles['set-view-subtitle']}>
+                    {t('StorageView.more_space')}
+                  </h3>
+                  <ButtonLink
+                    theme='regular'
+                    className={styles['set-offer-button']}
+                    href={storageData.offersLink}
+                    target
+                  >
+                    {t('StorageView.see_offer')}
+                  </ButtonLink>
+                </div>
+              }
             </div>
           )
         }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -94,7 +94,9 @@
     "title": "Storage",
     "load_error": "An error occured while loading your storage information, please try again later.",
     "storage_title": "Total space",
-    "storage_phrase": "%{diskUsage} GB of %{diskQuota} GB used"
+    "storage_phrase": "%{diskUsage} GB of %{diskQuota} GB used",
+    "more_space": "Need more storage space?",
+    "see_offer": "Upgrade my Cozy"
   },
   "SessionsView": {
     "title": "Connection history",

--- a/src/styles/storage.styl
+++ b/src/styles/storage.styl
@@ -1,0 +1,45 @@
+progress.set-storage-bar[value]
+  /* Reset the default appearance */
+  appearance none
+  background-color paleGrey
+  border solid 1px silver
+  border-radius: 2px
+  color dodgerBlue
+  height 1.5rem
+  margin 0 0 1rem 0
+  width 100%
+
+
+progress.set-storage-bar[value]::-webkit-progress-bar
+  background paleGrey
+  border-radius 2px
+
+
+progress.set-storage-bar[value]::-webkit-progress-value
+  background dodgerBlue
+  border-radius 1px
+
+
+progress.set-storage-bar[value]::-moz-progress-bar
+  background dodgerBlue
+  border-radius 1px
+
+
+.set-bar-percent
+    position absolute
+    left 2.5rem
+    padding-top .2rem
+    color white
+    &.--dark
+        color black
+
+.set-offer-button
+    color white!important //@stylint ignore
+    margin 1rem 0
+    width  100%
+
+.set-offer-button:hover
+.set-offer-button:active
+.set-offer-button:focus
+.set-offer-button:visited
+    color white!important //@stylint ignore

--- a/src/styles/view.styl
+++ b/src/styles/view.styl
@@ -5,6 +5,7 @@
     padding-right  2rem
 
     .set-view-title
+    .set-view-subtitle
         padding  0
 
     .set-view-subtitle
@@ -33,39 +34,3 @@
     padding .2em 0
     background           transparent
     color                dodgerBlue
-
-progress.set-storage-bar[value]
-  /* Reset the default appearance */
-  appearance none
-  background-color paleGrey
-  border solid 1px silver
-  border-radius: 2px
-  color dodgerBlue
-  height 1.5rem
-  margin 0 0 1rem 2rem
-  width calc(100% - 4rem)
-  max-width 30rem
-
-
-progress.set-storage-bar[value]::-webkit-progress-bar
-  background paleGrey
-  border-radius 2px
-
-
-progress.set-storage-bar[value]::-webkit-progress-value
-  background dodgerBlue
-  border-radius 1px
-
-
-progress.set-storage-bar[value]::-moz-progress-bar
-  background dodgerBlue
-  border-radius 1px
-
-
-.set-bar-percent
-    position absolute
-    left 2.5rem
-    padding-top .2rem
-    color white
-    &.--dark
-        color black


### PR DESCRIPTION
The offers link is compute from an URL in the context and the UUID of the instance. If one of these parameters are missing or `null` this part won't be displayed in the view.
<img width="820" alt="screen shot 2018-01-17 at 10 28 31" src="https://user-images.githubusercontent.com/10224453/35035420-94e36184-fb71-11e7-8a83-40acba10cfab.png">
