### PR TITLE
Add gather action

### DIFF
--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -53,10 +53,10 @@ export const fetchClaudyInfos = () => {
 
 export const consolidateClaudyActionsInfos = (claudyActions) => {
   const ACTIONS_WITH_DEVICES = ['desktop', 'mobile']
-  const ACTIONS_WITH_ACCOUNTS = ['cozy-collect']
+  const ACTIONS_WITH_ACCOUNTS = ['cozy-collect', 'gather']
   return async (dispatch, getState) => {
     let apps = []
-    let collectAccounts = []
+    let accounts = []
     // if at least one action requires app links
     if (claudyActions.find(a => a.link && a.link.type === 'apps')) {
       try {
@@ -74,13 +74,13 @@ export const consolidateClaudyActionsInfos = (claudyActions) => {
     // if at least one action requires devices infos
     if (claudyActions.find(a => ACTIONS_WITH_ACCOUNTS.includes(a.slug))) {
       try {
-        collectAccounts = await getAllAccounts()
+        accounts = await getAllAccounts()
       } catch (e) {
         console.warn && console.warn('Cannot fetch accounts infos for Claudy.')
-        collectAccounts = [] // keep list empty if apps cannot be fetched
+        accounts = [] // keep list empty if apps cannot be fetched
       }
     }
-    dispatch({ type: FETCH_CLAUDY_INFOS_SUCCESS, claudyActions, apps, collectAccounts })
+    dispatch({ type: FETCH_CLAUDY_INFOS_SUCCESS, claudyActions, apps, accounts })
   }
 }
 

--- a/src/config/claudyActions.yaml
+++ b/src/config/claudyActions.yaml
@@ -15,6 +15,13 @@ cozy-collect:
     appSlug: collect
     path: '/intro'
 
+gather:
+  icon: icon-bills.svg
+  link:
+    type: apps
+    appSlug: home
+    path: '/intro'
+
 support:
   icon: icon-question-mark.svg
   component: /Support

--- a/src/reducers/claudy.js
+++ b/src/reducers/claudy.js
@@ -28,10 +28,10 @@ export const apps = (state = [], action) => {
   }
 }
 
-export const collectAccounts = (state = [], action) => {
+export const accounts = (state = [], action) => {
   switch (action.type) {
     case FETCH_CLAUDY_INFOS_SUCCESS:
-      return action.collectAccounts
+      return action.accounts
     default:
       return state
   }
@@ -67,7 +67,7 @@ export const isFetching = (state = false, action) => {
 const claudy = combineReducers({
   actions,
   apps,
-  collectAccounts,
+  accounts,
   devices,
   error,
   isFetching

--- a/src/services/Claudy.jsx
+++ b/src/services/Claudy.jsx
@@ -11,6 +11,7 @@ const MOBILE_CLIENT_KIND = 'mobile'
 const DESKTOP_CLIENT_KIND = 'desktop'
 
 const CLAUDY_ACTION_COLLECT = 'cozy-collect'
+const CLAUDY_ACTION_GATHER = 'gather'
 
 export class Claudy extends Component {
   constructor (props, context) {
@@ -76,14 +77,15 @@ export class Claudy extends Component {
   consolidateActions (claudyInfos) {
     return claudyInfos.actions.map(action => {
       switch (action.slug) {
-        case 'desktop':
+        case DESKTOP_CLIENT_KIND:
           action.complete = !!claudyInfos.devices.find(d => d.client_kind === DESKTOP_CLIENT_KIND)
           break
-        case 'mobile':
+        case MOBILE_CLIENT_KIND:
           action.complete = !!claudyInfos.devices.find(d => d.client_kind === MOBILE_CLIENT_KIND)
           break
-        case 'cozy-collect':
-          action.complete = !!claudyInfos.collectAccounts.length
+        case CLAUDY_ACTION_COLLECT:
+        case CLAUDY_ACTION_GATHER:
+          action.complete = !!claudyInfos.accounts.length
           break
         default:
           action.complete = false
@@ -200,16 +202,16 @@ export class Claudy extends Component {
                   <p className='coz-claudy-menu-action-title'>
                     {t(`claudy.actions.${action.slug}.title`)}
                   </p>
-                  {action.complete && action.slug !== CLAUDY_ACTION_COLLECT &&
+                  {action.complete && ![CLAUDY_ACTION_COLLECT, CLAUDY_ACTION_GATHER].includes(action.slug) &&
                     <img
                       className='coz-claudy-menu-action-check'
                       src={this.checkIcon}
                     />
                   }
-                  {action.complete && action.slug === CLAUDY_ACTION_COLLECT &&
+                  {action.complete && ![CLAUDY_ACTION_COLLECT, CLAUDY_ACTION_GATHER].includes(action.slug) &&
                     <div className='coz-claudy-menu-action-count-wrapper'>
                       <span className='coz-claudy-menu-action-count'>
-                        {claudyInfos.collectAccounts.length}
+                        {claudyInfos.accounts.length}
                       </span>
                     </div>
                   }


### PR DESCRIPTION
The gather action is the same as cozy-collect, so this PR rename the variables related to collect, but keeps also the cozy-collect action to ensure legacy. The cozy-collect action should be removed soon, once the Cozy-Bar will be updated.