### PR TITLE
Get app slug from stack

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -26,6 +26,7 @@
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-name-prefix="{{.AppNamePrefix}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"

--- a/src/services.ejs
+++ b/src/services.ejs
@@ -26,6 +26,7 @@
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-app-name="{{.AppName}}"
   data-cozy-app-name-prefix="{{.AppNamePrefix}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-icon-path="{{.IconPath}}"
 >


### PR DESCRIPTION
Necessary to use the new cozy-bar navigation
and the home app detection