### PR TITLE
Do not freeze the browser on support email sent

### DIFF
--- a/src/services/ClaudyActionComponents/Support.jsx
+++ b/src/services/ClaudyActionComponents/Support.jsx
@@ -23,7 +23,11 @@ export class Support extends Component {
     }
 
     // if message successfully sent
-    if (nextProps.emailStatus.isSent && this.props.emailStatus.isSending) {
+    if (
+      nextProps.emailStatus.isSent &&
+      this.props.emailStatus.isSending &&
+      !this.props.emailStatus.isSent
+    ) {
       this.setState({ message: '' })
       // usually go back on success
       this.props.onSuccess(this.props.t('claudy.actions.support.success'))


### PR DESCRIPTION
In the claudy intent, the user can send an email to the support. When it's done, claudy comes back to the list of actions. But the componentWillReceiveProps method of Support was calling the goBack method of Claudy, when it makes React re-rendering and calling again the first method, etc. To fix that, we have added a condition to break the loop. It is a quick fix, a proper refactoring would need more work but could clean a lot more.
