### PR TITLE
fix: Use ua-parser-js for reading user-agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
-    "user-agent-parser": "0.6.0"
+    "ua-parser-js": "0.7.19"
   }
 }

--- a/src/components/SessionsViewRow.jsx
+++ b/src/components/SessionsViewRow.jsx
@@ -2,12 +2,12 @@ import tableStyles from '../styles/table'
 
 import React from 'react'
 import classNames from 'classnames'
-import parser from 'user-agent-parser'
+import { UAParser } from 'ua-parser-js'
 
 import { translate } from 'cozy-ui/react/I18n'
 
 const SessionsViewRow = ({ f, t, session }) => {
-  const ua = parser(session.user_agent)
+  const ua = UAParser(session.user_agent)
   return (
     <div className={tableStyles['coz-table-row']}>
       <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -8112,7 +8112,6 @@ pouchdb-abstract-mapreduce@6.4.3:
 
 "pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
   resolved "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
   dependencies:
     pouchdb-adapter-websql-core "^6.1.1"
@@ -10671,6 +10670,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+ua-parser-js@0.7.19:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
+
 uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
@@ -10864,11 +10868,6 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
-
-user-agent-parser@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/user-agent-parser/-/user-agent-parser-0.6.0.tgz#00dd819143ca12240f23e91fcdc8b31f3b6e92a2"
-  integrity sha1-AN2BkUPKEiQPI+kfzcizHztukqI=
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
The user-agent-parser package on npm has been deprecated in favor of ua-parser-js. Let's use the modern alternative, with support for the recent browsers and OS.

Fix #154
