### PR TITLE
[WIP] Uses cozy-client, removes cozy-client-js and other ad-hoc clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn.lock # Remove this one on your app
 
 # Build
 build/
-
+coverage/
 
 # Locales
 **/locales/*

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,6 +2,7 @@
 /*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import emailHelper from 'lib/emailHelper'
+import { getStackClient } from 'lib/cozyClient'
 
 export let STACK_DOMAIN = null
 export let STACK_TOKEN = null
@@ -303,29 +304,7 @@ export const deleteOtherSessions = () => {
 }
 
 export const cozyFetch = (method, path, body) => {
-  let params = {
-    method: method,
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${STACK_TOKEN}`
-    }
-  }
-  if (body) {
-    params.body = JSON.stringify(body)
-  }
-  return fetch(`${STACK_DOMAIN}${path}`, params).then(response => {
-    let data
-    const contentType = response.headers.get('content-type')
-    if (contentType && contentType.indexOf('json') >= 0) {
-      data = response.json()
-    } else {
-      data = response.text()
-    }
-
-    return response.status >= 200 && response.status <= 204
-      ? data
-      : data.then(Promise.reject.bind(Promise))
-  })
+  return getStackClient()
+    .fetchJSON(method, path, body)
+    .catch(fetchError => fetchError.reason || fetchError)
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,4 +1,5 @@
 /* global fetch */
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import emailHelper from 'lib/emailHelper'
 

--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -1,4 +1,5 @@
 /* global cozy */
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import CLAUDY_ACTIONS from 'config/claudyActions'
 

--- a/src/containers/Profile.jsx
+++ b/src/containers/Profile.jsx
@@ -1,3 +1,5 @@
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
+
 import { connect } from 'react-redux'
 
 import { translate } from 'cozy-ui/react/I18n'

--- a/src/lib/cozyClient.js
+++ b/src/lib/cozyClient.js
@@ -1,0 +1,21 @@
+import CozyClient from 'cozy-client'
+
+let client = null
+
+export function getClient() {
+  if (!client && /comp|inter|loaded/.test(document.readyState)) {
+    const root = document.querySelector('[role=application]')
+    const data = root.dataset
+    const protocol = window.location.protocol
+    client = new CozyClient({
+      uri: `${protocol}//${data.cozyDomain}`,
+      schema: {},
+      token: data.cozyToken
+    })
+  }
+  return client
+}
+
+export function getStackClient() {
+  return getClient().getStackClient()
+}

--- a/src/services/Claudy.jsx
+++ b/src/services/Claudy.jsx
@@ -1,4 +1,5 @@
 /* global __PIWIK_TRACKER_URL__  __PIWIK_SITEID__ __PIWIK_DIMENSION_ID_APP__ */
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -10,7 +10,7 @@ import { Provider, connect } from 'react-redux'
 import { compose, createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import { createLogger } from 'redux-logger'
-import CozyClient from 'cozy-client'
+import { getClient } from 'lib/cozyClient'
 
 import I18n from 'cozy-ui/react/I18n'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
@@ -53,12 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     token: data.cozyToken
   })
 
-  const protocol = window.location.protocol
-  const cozyClient = new CozyClient({
-    uri: `${protocol}//${data.cozyDomain}`,
-    schema: {},
-    token: data.cozyToken
-  })
+  const cozyClient = getClient()
 
   cozy.bar.init({
     cozyClient,

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,5 +1,6 @@
 /* global __DEVELOPMENT__ */
 /* global cozy */
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import 'styles/index.styl'
 

--- a/test/lib/getClient.spec.js
+++ b/test/lib/getClient.spec.js
@@ -1,0 +1,53 @@
+import { getClient } from '../../src/lib/cozyClient'
+import CozyClient from 'cozy-client'
+jest.mock('cozy-client')
+
+const FAKE_APP_TOKEN =
+  'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcHAiLCJpYXQiOjE1NTYxMTIwOTQsImlzcyI6ImVkYXMubXljb3p5LmNsb3VkIiwic3ViIjoiaG9tZSIsInNlc3Npb25faWQiOiI4YjI1ZTgzNTkwYTg5MDg0MDUzNDIxZGE0ZmZlOTMwNiJ9.gA3Xnoliu43gwpuO88O6G59rVP_HClZ_vBp96pEjVNnZDpxU4ZnQoWmICoLXih4PvFZRj2eHjnG-eqnJx6XM2A'
+
+const FAKE_APP_DOMAIN = 'test.mycozy.cloud'
+
+const FAKE_APP_BODY = `<div role="application" data-cozy-token="${FAKE_APP_TOKEN}" data-cozy-domain="${FAKE_APP_DOMAIN}" data-cozy-locale="fr" data-cozy-app-editor="Cozy" data-cozy-app-name="Accueil" data-cozy-app-name-prefix="Cozy" data-cozy-app-slug="home" data-cozy-tracking="false" data-cozy-icon-path="icon.svg"><script src="vendors/home.a664629f1a5622ccb459.js"></script><script src="app/home.455bbc269323b2c64382.js"></script><script src="//test.mycozy.cloud/assets/js/piwik.js" async></script></div>`
+
+/*
+const FAKE_APP_HTML = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"><title>Cozy Home</title>
+  <link rel="icon" href="//test.mycozy.cloud/assets/favicon.f56cf1d03b.ico">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-16x16.192a16308f.png" sizes="16x16">
+  <link rel="icon" type="image/png" href="//test.mycozy.cloud/assets/favicon-32x32.9f958fa2c7.png" sizes="32x32">
+  <link rel="apple-touch-icon" sizes="180x180" href="//test.mycozy.cloud/assets/apple-touch-icon.a0e0ae4102.png"/>
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials"><meta name="msapplication-TileColor" content="#2b5797"><meta name="theme-color" content="#ffffff"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1,viewport-fit=cover"><link rel="stylesheet" href="vendors/home.c451e5ac76c8377b20c5.0.min.css"><link rel="stylesheet" href="app/home.cbb1b1050b936df11fbd.min.css"><link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/styles/theme.faa4e12bdc.css"> <script src="//test.mycozy.cloud/assets/js/cozy-client.605c649bc3.min.js"></script>
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/fonts/fonts.33109548ca.css">
+<link rel="stylesheet" type="text/css" href="//test.mycozy.cloud/assets/css/cozy-bar.6effa2d88c.min.css">
+<script src="//test.mycozy.cloud/assets/js/cozy-bar.f99c08ee53.min.js"></script></head><body>${FAKE_APP_BODY}</body></html>
+`
+*/
+
+describe('getClient', () => {
+  beforeAll(() => {
+    document.body.innerHTML = FAKE_APP_BODY
+    Object.defineProperty(document, 'readyState', { value: 'loaded' })
+    delete global.window.location
+    global.window.location = new URL(`https://${FAKE_APP_DOMAIN}`)
+  })
+
+  beforeEach(() => {
+    CozyClient.mockClear()
+  })
+
+  it('should initialize a CozyClient instance', () => {
+    const res = getClient()
+    expect(CozyClient).toHaveBeenCalledTimes(1)
+    expect(res).toBeTruthy()
+    const arg = CozyClient.mock.calls[0][0]
+    expect(arg.uri).toEqual('https://test.mycozy.cloud')
+    expect(arg.token).toEqual(FAKE_APP_TOKEN)
+  })
+
+  it('should memoize the first call', () => {
+    getClient()
+    CozyClient.mockClear()
+    const res = getClient()
+    expect(CozyClient).toHaveBeenCalledTimes(0)
+    expect(res).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This is a work in progress.

The purpose is to migrate from cozy-client-js to the new cozy-client.
I won't seek the best architecture but instead will try to leave most code untouched.

- [x] cozyFetch dans actions/index.js
- [ ] URL dans components/export/ExportDownload
- [ ] Intents dans actions/services
- [ ] Jobs dans actions/email
- [ ] ??? dans components/IntentView
- [ ] Initialisation cozy-client.js dans package.json
- [ ] Initialisation cozy-client.js dans target/browser/index.[jsx,ejs]
- [ ] Initialisation cozy-client.js dans targets/intents/index.[jsx,ejs]
- [ ] Documentation cozy-client.js dans README.md
- [ ] Documentation cozy-client.js dans PULL_REQUEST_TEMPLATE.md

