### PR TITLE
Downgrade dependency cozy-ui to 19.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cozy-client": "6.24.1",
     "cozy-client-js": "0.14.2",
     "cozy-scripts": "1.13.0",
-    "cozy-ui": "19.30.2",
+    "cozy-ui": "19.29.0",
     "date-fns": "1.30.1",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,9 +848,9 @@
     regenerator-runtime "^0.12.0"
 
 "@babel/runtime@^7.3.4":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
-  integrity sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -2860,10 +2860,10 @@ cozy-stack-client@^6.24.1:
     mime-types "2.1.24"
     qs "6.7.0"
 
-cozy-ui@19.30.2:
-  version "19.30.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.30.2.tgz#9e10d4a687c6db0de91b386d1cc9d1ea9176341d"
-  integrity sha512-U7B2eyw1CahlmDN7JfxqSK6MVrEvLPgu0sMRZaaevLMn2ymutPxPKz3TLgmQHFSRiPgUzRdMM52ifRZt4p3uBg==
+cozy-ui@19.29.0:
+  version "19.29.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.29.0.tgz#35ca922a2eab052fb54ffbd4a6767703e02c536d"
+  integrity sha512-IPHzEpyrP9D0Kl870ABgpJelYXXnH7mJt12p21qjz2XAZx1FaK8OtYIHrwU/Jm233FsO6g72FD5FF6ATvm4P2A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
The goal is to be able to use AppLinker without introducing regressions due to last changes in cozy-ui variable names