### PR TITLE
fix: Also responds to normal value reducer

### DIFF
--- a/src/actions/twoFactor.js
+++ b/src/actions/twoFactor.js
@@ -1,5 +1,12 @@
 import { cozyFetch } from 'actions'
 
+/**
+ * The order of actions
+ *
+ * 1. ACTIVATE_FA
+ * 2. CHECK_TWO_FACTOR_CODE
+ */
+
 export const ACTIVATE_2FA = 'ACTIVATE_2FA'
 export const ACTIVATE_2FA_FAILURE = 'ACTIVATE_2FA_FAILURE'
 export const ACTIVATE_2FA_SUCCESS = 'ACTIVATE_2FA_SUCCESS'

--- a/src/reducers/fields.js
+++ b/src/reducers/fields.js
@@ -14,8 +14,18 @@ import {
   AUTH_MODE
 } from 'actions/twoFactor'
 
+const composeReducers = (...fns) => {
+  return (state, action) => {
+    for (let i = 0; i < fns.length; i++) {
+      const reducer = fns[fns.length - i - 1]
+      state = reducer(state, action)
+    }
+    return state
+  }
+}
+
 /** Special reducer for the auth_mode value */
-const authModeValue = (state = '', action) => {
+const authModeValue = (state = AUTH_MODE.BASIC, action) => {
   switch (action.type) {
     case CHECK_TWO_FACTOR_CODE_SUCCESS:
       return AUTH_MODE.TWO_FA_MAIL
@@ -38,7 +48,10 @@ const createField = name => {
     }
   }
 
-  const value = name == 'auth_mode' ? authModeValue : normalValue
+  const value =
+    name == 'auth_mode'
+      ? composeReducers(authModeValue, normalValue)
+      : normalValue
 
   const submitting = (state = false, action) => {
     if (name !== action.field) return state

--- a/src/reducers/fields.spec.js
+++ b/src/reducers/fields.spec.js
@@ -1,4 +1,7 @@
 import fields from './fields'
+
+import { FETCH_INFOS_SUCCESS } from '../actions'
+
 import {
   CHECK_TWO_FACTOR_CODE_SUCCESS,
   DESACTIVATE_2FA_SUCCESS,
@@ -48,7 +51,7 @@ describe('fields reducer', () => {
     })
   })
 
-  describe('two fa', () => {  
+  describe('two fa', () => {
     it('should react to two fa actions', () => {
       state = fields(state, {
         type: CHECK_TWO_FACTOR_CODE_SUCCESS
@@ -59,6 +62,19 @@ describe('fields reducer', () => {
       })
       expect(state.auth_mode.value).toBe(AUTH_MODE.BASIC)
     })
-  })
 
+    it('should react to normal actions', () => {
+      state = fields(state, {
+        type: FETCH_INFOS_SUCCESS,
+        instance: {
+          data: {
+            attributes: {
+              auth_mode: AUTH_MODE.TWO_FA_MAIL
+            }
+          }
+        }
+      })
+      expect(state.auth_mode.value).toBe('two_factor_mail')
+    })
+  })
 })

--- a/src/reducers/fields.spec.js
+++ b/src/reducers/fields.spec.js
@@ -48,14 +48,17 @@ describe('fields reducer', () => {
     })
   })
 
-  it('should react to two fa actions', () => {
-    state = fields(state, {
-      type: CHECK_TWO_FACTOR_CODE_SUCCESS
+  describe('two fa', () => {  
+    it('should react to two fa actions', () => {
+      state = fields(state, {
+        type: CHECK_TWO_FACTOR_CODE_SUCCESS
+      })
+      expect(state.auth_mode.value).toBe(AUTH_MODE.TWO_FA_MAIL)
+      state = fields(state, {
+        type: DESACTIVATE_2FA_SUCCESS
+      })
+      expect(state.auth_mode.value).toBe(AUTH_MODE.BASIC)
     })
-    expect(state.auth_mode.value).toBe(AUTH_MODE.TWO_FA_MAIL)
-    state = fields(state, {
-      type: DESACTIVATE_2FA_SUCCESS
-    })
-    expect(state.auth_mode.value).toBe(AUTH_MODE.BASIC)
   })
+
 })


### PR DESCRIPTION
The auth_mode field should react to two fa actions, *as well* as normal value actions. Checkbox would not show its state otherwise.