### PR TITLE
fix: Styles need $icon-spinner-blue placeholder

### DIFF
--- a/src/styles/fields.styl
+++ b/src/styles/fields.styl
@@ -1,4 +1,5 @@
 @require 'cozy-ui'
+@require './spinner.styl'
 
 [role=application]
     :local

--- a/src/styles/loading.styl
+++ b/src/styles/loading.styl
@@ -1,4 +1,5 @@
 @require 'cozy-ui'
+@require './spinner.styl'
 
 .set-loading
   text-align center

--- a/src/styles/loading.styl
+++ b/src/styles/loading.styl
@@ -5,12 +5,12 @@
   text-align center
   &:before
     content     ''
-    margin      em(80px) auto 0
-    width       em(80px)
-    height      em(80px)
+    margin      rem(80px) auto 0
+    width       rem(80px)
+    height      rem(80px)
     @extend $icon-spinner-blue
 
   p
-    margin-top  em(15px)
+    margin-top  rem(15px)
     color       grey-11
     line-height 1.5

--- a/src/styles/spinner-blue.svg
+++ b/src/styles/spinner-blue.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='12' height='12' fill='#297ef2'>
+  <path opacity='.25' d='M16 0a16 16 0 0 0 0 32 16 16 0 0 0 0-32m0 4a12 12 0 0 1 0 24 12 12 0 0 1 0-24'/>
+  <path d='M16 0a16 16 0 0 1 16 16h-4a12 12 0 0 0-12-12z'/>
+</svg>

--- a/src/styles/spinner.styl
+++ b/src/styles/spinner.styl
@@ -1,0 +1,6 @@
+@require 'cozy-ui'
+
+$icon-spinner-blue
+    @extend           $icon
+    @extend           $spin-anim
+    background-image  embedurl('./spinner-blue.svg')

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -4,8 +4,8 @@
 $set-device
     content         ''
     display         inline-block
-    width           em(30px)
-    height          em(30px)
+    width           rem(30px)
+    height          rem(30px)
     vertical-align  middle
 
 .set-loading
@@ -48,7 +48,7 @@ $set-device
         // quick fix for cozy-ui table layout issue
         height auto!important //@stylint ignore
         .coz-table-primary
-            padding-left em(80px)
+            padding-left rem(80px)
 
     .set-table-sessions
         // quick fix for cozy-ui table layout issue
@@ -58,10 +58,10 @@ $set-device
         font-size  1rem
 
     .set-device-laptop
-        background embedurl('../assets/icons/icon-device-laptop.svg') em(32px) center no-repeat
+        background embedurl('../assets/icons/icon-device-laptop.svg') rem(32px) center no-repeat
 
     .set-device-phone
-        background embedurl('../assets/icons/icon-device-phone.svg') em(32px) center no-repeat
+        background embedurl('../assets/icons/icon-device-phone.svg') rem(32px) center no-repeat
 
     +small-screen()
         .set-table-name

--- a/src/styles/table.styl
+++ b/src/styles/table.styl
@@ -1,4 +1,5 @@
 @require 'cozy-ui'
+@require './spinner.styl'
 
 $set-device
     content         ''

--- a/src/styles/view.styl
+++ b/src/styles/view.styl
@@ -1,4 +1,5 @@
 @require 'cozy-ui'
+@require './spinner.styl'
 
 .set-view-content
     padding-left   2rem


### PR DESCRIPTION
Cozy-ui has removed $icon-spinner-blue but settings is still
using it. Copy back the $icon-spinner-blue placeholder in settings.