### PR TITLE
chore: Remove console eslint warnings

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,6 +12,7 @@ if (document.querySelector('[role=application]')) {
 }
 
 if (!(STACK_TOKEN || STACK_DOMAIN)) {
+  // eslint-disable-next-line no-console
   console.error(
     'Settings need the Cozy URL and the token to work correctly. Elements not found.'
   )
@@ -100,8 +101,10 @@ export const fetchStorageData = () => {
       }
     } catch (e) {
       if (e.error && e.error !== 'Not Found') {
+        // eslint-disable-next-line no-console
         console.warn(e)
       } else if (!e.error) {
+        // eslint-disable-next-line no-console
         console.warn(e)
       }
     }

--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -70,7 +70,9 @@ export const consolidateClaudyActionsInfos = claudyActions => {
         const appsResponse = await cozyFetch('GET', '/apps/')
         apps = appsResponse.data
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.warn &&
+          // eslint-disable-next-line no-console
           console.warn('Cannot fetch client devices infos for Claudy.')
         apps = [] // keep list empty if apps cannot be fetched
       }
@@ -84,6 +86,8 @@ export const consolidateClaudyActionsInfos = claudyActions => {
       try {
         accounts = await getAllAccounts()
       } catch (e) {
+        // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console
         console.warn && console.warn('Cannot fetch accounts infos for Claudy.')
         accounts = [] // keep list empty if apps cannot be fetched
       }

--- a/src/containers/Profile.jsx
+++ b/src/containers/Profile.jsx
@@ -41,6 +41,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       await dispatch(requestExport())
       Alerter.success(ownProps.t('ProfileView.export.success'))
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e)
     }
   },
@@ -60,21 +61,26 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(desactivate2FA(mode))
   },
   onPassphraseSimpleSubmit: (current, newVal) => {
-    return dispatch(updatePassphrase(current, newVal))
-      .then(() => Alerter.info(ownProps.t('ProfileView.password.reload')))
-      .catch(e => console.error(e))
+    return (
+      dispatch(updatePassphrase(current, newVal))
+        .then(() => Alerter.info(ownProps.t('ProfileView.password.reload')))
+        // eslint-disable-next-line no-console
+        .catch(e => console.error(e))
+    )
   },
   onPassphrase2FAStep1: current => {
     return dispatch(updatePassphrase2FAFirst(current)).catch(e =>
+      // eslint-disable-next-line no-console
       console.error(e)
     )
   },
   onPassphrase2FAStep2: (newVal, twoFactorCode, twoFactorToken) => {
-    return dispatch(
-      updatePassphrase2FASecond(newVal, twoFactorCode, twoFactorToken)
+    return (
+      dispatch(updatePassphrase2FASecond(newVal, twoFactorCode, twoFactorToken))
+        .then(() => Alerter.info(ownProps.t('ProfileView.password.reload')))
+        // eslint-disable-next-line no-console
+        .catch(e => console.error(e))
     )
-      .then(() => Alerter.info(ownProps.t('ProfileView.password.reload')))
-      .catch(e => console.error(e))
   }
 })
 

--- a/src/services/Claudy.jsx
+++ b/src/services/Claudy.jsx
@@ -63,6 +63,7 @@ export class Claudy extends Component {
     const { t, claudyInfos } = this.props
     if (action.link.type === 'apps' && action.link.appSlug) {
       if (!claudyInfos.apps || !claudyInfos.apps.length) {
+        // eslint-disable-next-line no-console
         console.warn('No apps found on the Cozy')
         return null
       }
@@ -73,6 +74,7 @@ export class Claudy extends Component {
         const appUrl = `${app.links.related}${action.link.path || ''}`
         return appUrl
       } else {
+        // eslint-disable-next-line no-console
         console.warn(
           `No app with slug '${action.link.appSlug}' found on the Cozy.`
         )

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -38,6 +38,7 @@ const EnhancedI18n = connect(state => {
   try {
     cozy.bar.setLocale && cozy.bar.setLocale(lang)
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn(`The dict phrases for "${lang}" can't be loaded`)
   }
   return { lang }


### PR DESCRIPTION
Those console calls seem to be here for a long time and are causing warnings in the linter.