### PR TITLE
Remove CozyProvider store prop

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   render(
-    <CozyProvider client={cozyClient} store={store}>
+    <CozyProvider client={cozyClient}>
       <Provider store={store}>
         <EnhancedI18n dictRequire={lang => require(`locales/${lang}`)}>
           <PiwikHashRouter>


### PR DESCRIPTION
Passing a prop was making any query to never update its fetchstatus.
Related to https://github.com/cozy/cozy-client/issues/439