### PR TITLE
feat: Make app name translatable

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "manifest": {
+    "name": "Settings"
+  },
   "DeleteAccount": {
     "title" : "Delete your account",
     "label" : "You can delete you Cozy at anytime. Be careful, once your account is deleted, your data will entirely be deleted, there is no going back.",


### PR DESCRIPTION
Adding the `manifest` field in the translations so that we can change the app's name depending on the locale, through transifex.