### PR TITLE
Mail limit

### DIFF
--- a/src/components/DeleteAccount/FormModal.jsx
+++ b/src/components/DeleteAccount/FormModal.jsx
@@ -19,7 +19,7 @@ const ERRORED = 'errored'
 const IDLE = 'idle'
 const SENDING = 'sending'
 
-const REASON_MAXLENGTH = 500
+const REASON_MAXLENGTH = 3000
 
 export class FormModal extends Component {
   state = {

--- a/src/components/DeleteAccount/FormModal.jsx
+++ b/src/components/DeleteAccount/FormModal.jsx
@@ -75,7 +75,7 @@ export class FormModal extends Component {
             <div className={styles['coz-textarea-wrapper']}>
               <textarea
                 aria-busy={isSending}
-                maxength={REASON_MAXLENGTH}
+                maxLength={REASON_MAXLENGTH}
                 readOnly={isSending}
                 ref={element => {
                   this.reasonElement = element


### PR DESCRIPTION
The (arbitrary) limit for the message when deleting a cozy was too small for some feedback messages, and the user was not aware that there was a limit on the message size. This PR fixes both issues.