### PR TITLE
fix(PassphraseForm): Make password advice align properly with text

### DIFF
--- a/src/styles/passphrase.styl
+++ b/src/styles/passphrase.styl
@@ -1,4 +1,4 @@
 .set-passphrase-advices
     p
-        display inline-block
+        display inline
         margin 0


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1606068/72087657-22376780-3309-11ea-88d9-e0a4e633979f.png)

After:
![image](https://user-images.githubusercontent.com/1606068/72087688-2d8a9300-3309-11ea-9d73-14cb4f2b363a.png)
