### PR TITLE
fix: Password strength rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cozy-doctypes": "^1.70.0",
     "cozy-keys-lib": "1.9.5",
     "cozy-scripts": "1.13.1",
-    "cozy-ui": "28.6.0",
+    "cozy-ui": "29.1.1",
     "date-fns": "1.30.1",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.7.2",

--- a/test/__snapshots__/app.spec.js.snap
+++ b/test/__snapshots__/app.spec.js.snap
@@ -7,7 +7,7 @@ exports[`App component only should be mounted correctly 1`] = `
   <Alerter
     into="body"
   />
-  <Wrapper />
+  <withI18n(Sidebar) />
   <Main>
     <Switch>
       <Route

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,10 +3232,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@28.6.0:
-  version "28.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.6.0.tgz#adf7011f60e2abe8959ce8102fd89df43b437b40"
-  integrity sha512-vurqenjQZMz6SPKTtLzQPq8v1V04Fl+kPWp+0u9KUon9u6thVeW7Qr3seLT/9Uo/oiIZSzX4n4/AYlkKpSVPxw==
+cozy-ui@29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.1.1.tgz#cca0cae2dd676e65926d7594441003cc2d613a2a"
+  integrity sha512-ZRkMO8y0nbxhpLOInawk2isauv49MEP0U+Pig+CcMQYMVkqoTJeZlpy4JdXGY8IJCVpv8dZ5lDlAuub4CHujJw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
The password strength rendering was buggy:

* It was "jumping" between strength levels while typing the password
* The strength changed when interacting with a totally not related input

The bug was fixed in cozy-ui v29.1.1, see
https://github.com/cozy/cozy-ui/releases/tag/v29.1.1.