### PR TITLE
Fix email intent

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "cozy-scripts start --hot",
     "cozyPublish": "cozy-scripts publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost",
     "pretest": "yarn lint",
-    "test": "cozy-scripts test --verbose --coverage",
+    "test": "cozy-scripts test",
     "stack:docker": "docker run --rm -it -p 8080:8080 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev"
   },
   "repository": {

--- a/src/reducers/emailStatus.js
+++ b/src/reducers/emailStatus.js
@@ -21,6 +21,7 @@ export const isSending = (state = false, action) => {
   switch (action.type) {
     case SEND_EMAIL:
       return true
+    case SEND_EMAIL_SUCCESS:
     case SEND_EMAIL_FAILURE:
       return false
     default:

--- a/src/reducers/emailStatus.spec.js
+++ b/src/reducers/emailStatus.spec.js
@@ -1,0 +1,51 @@
+import emailStatusReducer from './emailStatus'
+import {
+  SEND_EMAIL,
+  SEND_EMAIL_SUCCESS,
+  SEND_EMAIL_FAILURE
+} from '../actions/email'
+
+describe('emailStatus reducer', () => {
+  it('should return the initial state', () => {
+    expect(emailStatusReducer(undefined, {})).toEqual({
+      error: null,
+      isSending: false,
+      isSent: false
+    })
+  })
+
+  it('should send an email', () => {
+    let state = emailStatusReducer(state, { type: SEND_EMAIL })
+    expect(state).toEqual({
+      error: null,
+      isSending: true,
+      isSent: false
+    })
+
+    state = emailStatusReducer(state, { type: SEND_EMAIL_SUCCESS })
+    expect(state).toEqual({
+      error: null,
+      isSending: false,
+      isSent: true
+    })
+  })
+
+  it('should handle errors', () => {
+    let state = emailStatusReducer(state, { type: SEND_EMAIL })
+    expect(state).toEqual({
+      error: null,
+      isSending: true,
+      isSent: false
+    })
+
+    state = emailStatusReducer(state, {
+      type: SEND_EMAIL_FAILURE,
+      error: 'No flux capacitator'
+    })
+    expect(state).toEqual({
+      error: 'No flux capacitator',
+      isSending: false,
+      isSent: false
+    })
+  })
+})


### PR DESCRIPTION
Settings offers a contact form as an inter-app feature, which is notably used in the cozy bar. The form works, but there is no UI feedback when the email is sent, the spinners keep turning.

This was caused by a missing case in the reducer, fixed in this PR.