### PR TITLE
chore: Bump to 1.15.0

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -9,7 +9,7 @@
     "name": "Cozy",
     "url": "https://cozy.io"
   },
-  "version": "1.14.0",
+  "version": "1.15.0",
   "licence": "AGPL-3.0",
   "permissions": {
     "settings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-settings",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "src/index.jsx",
   "scripts": {
     "tx": "tx pull --all || true",


### PR DESCRIPTION
Bump to 1.15.0 since we're releasing an 1.14.0 version