### PR TITLE
fix: Fix the export page

### DIFF
--- a/src/components/export/ExportDownload.jsx
+++ b/src/components/export/ExportDownload.jsx
@@ -11,8 +11,8 @@ import formStyles from 'styles/fields.styl'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
 class ExportDownload extends Component {
-  componentDidMount(props) {
-    props.fetchExportData()
+  componentDidMount() {
+    this.props.fetchExportData()
   }
 
   download(cursor) {


### PR DESCRIPTION
A regression was introduced by a previous refactoring
(https://github.com/cozy/cozy-settings/commit/84676c2d3ad5df1e7bb76e50b39eadbc5ebb4734)

The componentDidMount function does not take props as an argument, but
from this.