### PR TITLE
Fix a typo in the Two steps authentication dialog

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,12 +105,12 @@
         "title": "Two steps authentication",
         "description": "Your Cozy sent a 6 digits validation code to %{email}.<br/>Entre the code inside to change your password:"
       },
-      "label": "Because two steps are better than one, improve your Cozy security with an additionnal step.<br/>[Check out our assistance website →](%{link})",
+      "label": "Because two steps are better than one, improve your Cozy security with an additional step.<br/>[Check out our assistance website →](%{link})",
       "modal": {
         "code": "code",
         "protect": "Protect your Cozy with two steps authentication",
         "change": "**What's changing?** Everytime you'll connect to your Cozy, you'll need your password and a validation code.<br/>[Check out our assistance website →](%{link})",
-        "secu_title": "Add an additionnal security level",
+        "secu_title": "Add an additional security level",
         "secu_description": "Password, that's good, but if it isn't \"complicated\", a thief can easily guess it. Receive a validation code by mail assures the control of your Cozy.",
         "protect_title": "Improve the protection of your data",
         "protect_description": "Even if a thief gets your password, you stay the only captain able to connect to your Cozy",


### PR DESCRIPTION
additional take only one n in english.