### PR TITLE
Add Move flag + fix delete account request

### DIFF
--- a/src/components/DeleteAccount/FormModal.jsx
+++ b/src/components/DeleteAccount/FormModal.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import compose from 'lodash/flowRight'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -7,6 +8,7 @@ import { sendDeleteAccountRequest } from 'actions/email'
 import { getStackDomain } from 'actions/domUtils'
 
 import styles from 'styles/deleteAccountFormModal.styl'
+import { withClient } from 'cozy-client'
 
 const DONE = 'done'
 const ERRORED = 'errored'
@@ -36,13 +38,14 @@ export class FormModal extends Component {
 
   onSend = async event => {
     event.preventDefault()
-    const { t } = this.props
+    const { client, t } = this.props
     const STACK_DOMAIN = getStackDomain()
     const domain = STACK_DOMAIN.replace('//', '')
     const reason = this.reasonElement.value
     this.setStatus(SENDING)
     try {
       await sendDeleteAccountRequest(
+        client,
         t('DeleteAccount.request.mail.subject', { domain }),
         reason.substring(0, REASON_MAXLENGTH)
       )
@@ -101,4 +104,7 @@ export class FormModal extends Component {
   }
 }
 
-export default translate()(FormModal)
+export default compose(
+  withClient,
+  translate()
+)(FormModal)

--- a/src/components/DeleteAccount/FormModal.spec.jsx
+++ b/src/components/DeleteAccount/FormModal.spec.jsx
@@ -50,7 +50,7 @@ describe('FormModal component', () => {
 
     fireEvent.click(root.getByText('Send'))
 
-    expect(sendDeleteAccountRequest.mock.calls[0][0]).toEqual(
+    expect(sendDeleteAccountRequest.mock.calls[0][1]).toEqual(
       expect.stringContaining(mockDomain)
     )
     jest.dontMock('actions/email')

--- a/src/components/export/ExportSection.jsx
+++ b/src/components/export/ExportSection.jsx
@@ -10,6 +10,8 @@ import ExportDownload from 'components/export/ExportDownload'
 
 import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
+import flag from 'cozy-flags'
+
 const exportImage = require('assets/images/export-cozy-mail.svg')
 
 class ExportSection extends Component {
@@ -49,15 +51,17 @@ class ExportSection extends Component {
           <Typography variant="h5" gutterBottom>
             {t('ProfileView.export.title')}
           </Typography>
-          <div className="u-mv-half">
-            <form
-              action={STACK_DOMAIN + '/move/initialize'}
-              method="post"
-              target="_blank"
-            >
-              <Button label={t('ProfileView.move.button')} extension="full" />
-            </form>
-          </div>
+          {flag('settings.moving-cozy') && (
+            <div className="u-mv-half">
+              <form
+                action={STACK_DOMAIN + '/move/initialize'}
+                method="post"
+                target="_blank"
+              >
+                <Button label={t('ProfileView.move.button')} extension="full" />
+              </form>
+            </div>
+          )}
           <Typography variant="body1" gutterBottom>
             {t('ProfileView.export.label')}
           </Typography>

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import { Provider, connect } from 'react-redux'
 import { CozyProvider } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import I18n from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
@@ -57,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const store = createStore()
   cozyClient.setStore(store)
+  cozyClient.registerPlugin(flag.plugin)
 
   cozy.bar.init({
     cozyClient,

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -6,6 +6,7 @@ import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 
 import { CozyProvider } from 'cozy-client'
+import flag from 'cozy-flags'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
@@ -44,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     uri: `${protocol}//${data.cozyDomain}`,
     token: data.cozyToken
   })
+  cozyClient.registerPlugin(flag.plugin)
 
   render(
     <StylesProvider generateClassName={generateClassName}>


### PR DESCRIPTION
- feat: Add flag for enable "cozy move"
- fix: Add client param to sendDeleteAccountRequest 
There was an error : "client.collection is not a function" when the user wants to delete their account.
because the client was missing in params of sendDeleteAccountRequest
