### PR TITLE
chore: Change matomo URL

### DIFF
--- a/config/webpack.config.piwik.js
+++ b/config/webpack.config.piwik.js
@@ -7,7 +7,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __PIWIK_SITEID__: 8,
       __PIWIK_DIMENSION_ID_APP__: 1,
-      __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc')
+      __PIWIK_TRACKER_URL__: JSON.stringify('https://matomo.cozycloud.cc')
     })
   ]
 }


### PR DESCRIPTION
Our matomo instance will now be available at matomo.cozycloud.cc
instead of piwik.cozycloud.cc.

#### Checklist

Before merging this PR, the following things must have been done:

- [ ] Faithful integration of the mockups at all screen sizes
- [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [ ] Localized in english and french
- [ ] All changes have test coverage
- [ ] Updated README, if necessary
