### PR TITLE
feat: Sort devices by name

### DIFF
--- a/src/components/DevicesView.jsx
+++ b/src/components/DevicesView.jsx
@@ -160,6 +160,7 @@ const DevicesView = props => {
   const {
     t,
     f,
+    lang,
     breakpoints: { isMobile }
   } = props
 
@@ -174,9 +175,16 @@ const DevicesView = props => {
   const devices = useMemo(
     () =>
       Array.isArray(data)
-        ? data.filter(device => DISPLAYED_CLIENTS.includes(device.client_kind))
+        ? data
+            .filter(device => DISPLAYED_CLIENTS.includes(device.client_kind))
+            .sort((a, b) => {
+              return a.client_name.localeCompare(b.client_name, lang, {
+                sensitivity: 'base',
+                numeric: true
+              })
+            })
         : [],
-    [data]
+    [data, lang]
   )
   const isFetching = useMemo(() => isQueryLoading({ fetchStatus }) || hasMore, [
     fetchStatus,


### PR DESCRIPTION
Although we're not supposed to add new features in a release branch, this small feature is almost a must have for people to find their Cozy Desktop OAuth client and configure it when they have a lot of clients. This is why we include it anyway.

Since we can't use mango queries to fetch OAuth clients, we need to sort them on the client side. Which means that we need to fetch all of them before displaying them (i.e. no `LoadMore` pagination on the client side).

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
- [ ] All changes have test coverage
- [x] Updated README, if necessary
