### PR TITLE
feat: Add direct route to device configuration

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -37,7 +37,8 @@ export class App extends Component {
             <Route path="/redirect" component={IntentRedirect} />
             <Route exact path="/profile" component={Profile} />
             <Route path="/profile/password" component={Passphrase} />
-            <Route path="/connectedDevices" component={Devices} />
+            <Route exact path="/connectedDevices" component={Devices} />
+            <Route path="/connectedDevices/:deviceId" component={Devices} />
             <Route path="/sessions" component={Sessions} />
             <Route path="/storage" component={Storage} />
             <Route path="/exports/:exportId" component={Profile} />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -234,6 +234,7 @@
   "DevicesView": {
     "title": "Connected devices",
     "load_error": "An error occured while loading your devices, please try again later.",
+    "device_load_error": "We could not find the requested device.",
     "load_more": "Load More",
     "head_name": "Name",
     "head_sync": "Last synchronisation",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -234,6 +234,7 @@
   "DevicesView": {
     "title": "Appareils connectés",
     "load_error": "Une erreur s'est produite lors du chargement de vos appareils, merci de réessayer plus tard.",
+    "device_load_error": "Nous ne trouvons pas l'appareil demandé.",
     "load_more": "Plus d'appareils",
     "head_name": "Nom",
     "head_sync": "Dernière synchronisation",

--- a/test/__snapshots__/app.spec.js.snap
+++ b/test/__snapshots__/app.spec.js.snap
@@ -29,7 +29,12 @@ exports[`App component only should be mounted correctly 1`] = `
       />
       <Route
         component={[Function]}
+        exact={true}
         path="/connectedDevices"
+      />
+      <Route
+        component={[Function]}
+        path="/connectedDevices/:deviceId"
       />
       <Route
         component={[Function]}


### PR DESCRIPTION
If a device id is passed in the connected devices route, we'll try to
find it in the devices list and open its configuration modal if found.

This will be used by the Cozy Desktop app to open its device
configuration.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
- [ ] All changes have test coverage
- [x] Updated README, if necessary
