### PR TITLE
fix: No trashed folders in device configuration

### DIFF
--- a/src/lib/deviceConfigurationHelper.js
+++ b/src/lib/deviceConfigurationHelper.js
@@ -17,8 +17,8 @@ const buildFoldersQuery = () =>
       name: { $gt: null }
     })
     .partialIndex({
-      _id: {
-        $ne: TRASH_DIR_ID
+      $not: {
+        path: { $regex: '^/.cozy_trash' }
       }
     })
     .indexFields(['path', 'type', 'name'])


### PR DESCRIPTION
We don't want to show trashed folders in the device configuration
modal allowing to exclude folders from the Desktop synchronization.
However, we only excluded the Trash itself from the folders query.

Besides loading unwanted folders, this was the cause of errors since
we would not find the parent of these folders (i.e. the Trash
document).
We now use a Regexp in the partial index selector to filter out all
trashed folders and the Trash itself.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
- [ ] All changes have test coverage
- [x] Updated README, if necessary
