### PR TITLE
fix: Force TreeView icons size

### DIFF
--- a/src/components/CozyTreeView.jsx
+++ b/src/components/CozyTreeView.jsx
@@ -14,8 +14,6 @@ const useItemClasses = divider =>
       minWidth: 'auto',
       marginRight: '1rem',
       padding: 0,
-      width: '1rem',
-      height: '1rem',
       justifyContent: 'center'
     },
     root: {
@@ -68,8 +66,8 @@ const useViewClasses = makeStyles(() => ({
 export const TreeView = ({ classes, children, ...other }) => {
   return (
     <MuiTreeView
-      defaultCollapseIcon={<BottomIcon />}
-      defaultExpandIcon={<RightIcon />}
+      defaultCollapseIcon={<BottomIcon width="1rem" height="1rem" />}
+      defaultExpandIcon={<RightIcon width="1rem" height="1rem" />}
       disableSelection={true}
       classes={mergeClasses({
         baseClasses: useViewClasses(),

--- a/src/components/__snapshots__/DevicesModaleConfigureView.spec.jsx.snap
+++ b/src/components/__snapshots__/DevicesModaleConfigureView.spec.jsx.snap
@@ -581,7 +581,9 @@ Object {
                           class="MuiTreeItem-iconContainer makeStyles-iconContainer-1155"
                         >
                           <svg
+                            height="1rem"
                             viewBox="0 0 16 16"
+                            width="1rem"
                           >
                             <path
                               d="M12.707 7.293l-6-6a.999.999 0 10-1.414 1.414L10.586 8l-5.293 5.293a.999.999 0 101.414 1.414l6-6a.999.999 0 000-1.414"
@@ -691,7 +693,9 @@ Object {
                             class="MuiTreeItem-iconContainer makeStyles-iconContainer-1158"
                           >
                             <svg
+                              height="1rem"
                               viewBox="0 0 16 16"
+                              width="1rem"
                             >
                               <path
                                 d="M12.707 7.293l-6-6a.999.999 0 10-1.414 1.414L10.586 8l-5.293 5.293a.999.999 0 101.414 1.414l6-6a.999.999 0 000-1.414"
@@ -1004,7 +1008,9 @@ Object {
                           class="MuiTreeItem-iconContainer makeStyles-iconContainer-1167"
                         >
                           <svg
+                            height="1rem"
                             viewBox="0 0 16 16"
+                            width="1rem"
                           >
                             <path
                               d="M12.707 7.293l-6-6a.999.999 0 10-1.414 1.414L10.586 8l-5.293 5.293a.999.999 0 101.414 1.414l6-6a.999.999 0 000-1.414"
@@ -1113,7 +1119,9 @@ Object {
                             class="MuiTreeItem-iconContainer makeStyles-iconContainer-1170"
                           >
                             <svg
+                              height="1rem"
                               viewBox="0 0 16 16"
+                              width="1rem"
                             >
                               <path
                                 d="M12.707 7.293l-6-6a.999.999 0 10-1.414 1.414L10.586 8l-5.293 5.293a.999.999 0 101.414 1.414l6-6a.999.999 0 000-1.414"


### PR DESCRIPTION
Safari won't display the `expand` and `collapse` icons of a `TreeView`
if their size is not specified.
We simply move the size definition from the container class to icon
props.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
- [x] All changes have test coverage
- [x] Updated README, if necessary
