### PR TITLE
feat: Configure Desktop from version 3.32.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
+    "semver": "^7.3.5",
     "ua-parser-js": "0.7.19"
   }
 }

--- a/src/components/DevicesView.jsx
+++ b/src/components/DevicesView.jsx
@@ -7,6 +7,7 @@ import get from 'lodash/get'
 import tableStyles from 'styles/table.styl'
 
 import flag from 'cozy-flags'
+import semver from 'semver'
 
 import ActionMenu, {
   ActionMenuHeader,
@@ -71,8 +72,9 @@ const getDeviceIcon = device => {
 const isCozyDesktopApp = device =>
   device.software_id === COZY_DESKTOP_SOFTWARE_ID
 const canConfigureDevice = device =>
-  flag('settings.partial-desktop-sync.show-synced-folders-selection') &&
-  isCozyDesktopApp(device)
+  isCozyDesktopApp(device) &&
+  semver.gte(device.software_version, '3.32.0-beta.2') &&
+  flag('settings.partial-desktop-sync.show-synced-folders-selection')
 
 const MoreButton = ({ onClick }) => {
   const { t } = useI18n()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7344,6 +7344,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lunr@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
@@ -10182,6 +10189,13 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -12066,6 +12080,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^11.1.1:
   version "11.1.1"


### PR DESCRIPTION
The partial synchronization configuration should only be available for
Desktop clients with a minimum version of 3.32.0-beta.2 as earlier
versions require a flag to be activated to handle partial
synchronization or don't handle it at all.

We still require the flag to be activated for the button to be shown
though.

We add a new dependency to `semver` to help us compare the Desktop 
clients' version with our minimum version.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [ ] Localized in english and french
- [ ] All changes have test coverage
- [ ] Updated README, if necessary
