### PR TITLE
fix: Configure Desktop from version 3.32.0-beta.3

### DIFF
--- a/src/components/DevicesView.jsx
+++ b/src/components/DevicesView.jsx
@@ -73,7 +73,7 @@ const isCozyDesktopApp = device =>
   device.software_id === COZY_DESKTOP_SOFTWARE_ID
 const canConfigureDevice = device =>
   isCozyDesktopApp(device) &&
-  semver.gte(device.software_version, '3.32.0-beta.2') &&
+  semver.gte(device.software_version, '3.32.0-beta.3') &&
   flag('settings.partial-desktop-sync.show-synced-folders-selection')
 
 const MoreButton = ({ onClick }) => {


### PR DESCRIPTION
The actual Desktop version activating partial synchronization support
in the core synchronization process without a flag is v3.32.0-beta.3
and not v3.32.0-beta.2 as stated in the previous commit.

This commit simply fixes this mistake.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [x] Localized in english and french
- [x] All changes have test coverage
- [x] Updated README, if necessary
