### PR TITLE
fix(deps): remove unused date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "cozy-keys-lib": "3.7.1",
     "cozy-realtime": "^3.13.1",
     "cozy-ui": "51.11.0",
-    "date-fns": "1.30.1",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.7.2",
     "react-markdown": "4.3.1",


### PR DESCRIPTION
date-fns is not used in the app (it is still present in yarn.lock because used in dependencies)

close #261 