### PR TITLE
fix : Remove a broken link 🔗

### DIFF
--- a/src/components/LanguageSection.jsx
+++ b/src/components/LanguageSection.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import ReactMarkdownWrapper from 'components/ReactMarkdownWrapper'
 import Select from 'components/Select'
 
 const LANG_OPTIONS = ['en', 'fr', 'es']
@@ -18,7 +16,6 @@ const LanguageSection = props => {
   }
   const selectedLocale = fields.locale.value
   const fieldName = 'locale'
-  console.log('coucou')
   return (
     <div>
       <Select

--- a/src/components/LanguageSection.jsx
+++ b/src/components/LanguageSection.jsx
@@ -18,6 +18,7 @@ const LanguageSection = props => {
   }
   const selectedLocale = fields.locale.value
   const fieldName = 'locale'
+  console.log('coucou')
   return (
     <div>
       <Select
@@ -35,9 +36,6 @@ const LanguageSection = props => {
         }}
         onChange={sel => onChange(fieldName, sel.value)}
       />
-      <Typography variant="body1" component="div">
-        <ReactMarkdownWrapper source={t('ProfileView.locale.contrib')} />
-      </Typography>
     </div>
   )
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -186,7 +186,6 @@
     "locale" : {
       "title" : "Sprache",
       "label": "Dies wird die Sprache sein, die in deinem Cozy verwendet wird.",
-      "contrib" : "Du bist daran interessiert, bei Cozys Übersetzung zu helfen? [Schau' hier, wie du uns **zur Hand gehen** kannst](https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937).",
       "fr": "Französisch ",
       "en": "Englisch",
       "es": "Spanisch",

--- a/src/locales/de_DE.json
+++ b/src/locales/de_DE.json
@@ -186,7 +186,6 @@
     "locale" : {
       "title" : "Sprache",
       "label": "Dies wird die Sprache sein, die in deinem Cozy verwendet wird.",
-      "contrib" : "Daran interessiert bei Cozys Übersetzung zu helfen? [Schau' hier wie du uns dabei helfen kannst](https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937).",
       "fr": "Französisch",
       "en": "Englisch",
       "es": "Spanisch",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -189,7 +189,6 @@
     "locale" : {
       "title" : "Language",
       "label": "This will be the language used in your Cozy.",
-      "contrib" : "Interested in helping translate Cozy? [Check out how you can **give us a hand** on that](https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937).",
       "fr": "French",
       "en": "English",
       "es": "Spanish",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -186,7 +186,6 @@
     "locale" : {
       "title" : "Idioma",
       "label": "Éste será el idioma utilizado en su Cozy.",
-      "contrib" : "¿Está usted interesado(a) en ayudar a traducir Cozy? [Mire a ver si puede **darnos una mano** en eso](https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937).",
       "fr": "Francés",
       "en": "Inglés",
       "es": "Español",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -189,7 +189,6 @@
     "locale" : {
       "title" : "Langue",
       "label": "C’est la langue de votre Cozy.",
-      "contrib" : "Vous voulez aider à traduire des applications de Cozy ? [Voilà comment nous aider](https://forum.cozy.io/t/comment-participer-a-la-traduction-de-cozy/3938).",
       "fr": "Français",
       "en": "Anglais",
       "es": "Espagnol",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -165,7 +165,6 @@
     "locale" : {
       "title" : "言語",
       "label": "Cozy で使用される言語です。",
-      "contrib" : "Cozy の翻訳に興味がありますか? [**私たちに手を差し伸べる方法**] (https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937)。",
       "fr": "フランス語",
       "en": "英語",
       "es": "スペイン語",

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -189,7 +189,6 @@
     "locale" : {
       "title" : "Taal",
       "label": "Dit is de taal die zal worden gebruikt in je Cozy.",
-      "contrib" : "Wil je meehelpen Cozy te vertalen? [Kijk dan op https://forum.cozy.io/t/how-to-contribute-to-the-cozy-localization/3937 hoe je een handje kunt helpen.]",
       "fr": "Frans",
       "en": "Engels",
       "es": "Spaans",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,9 +10252,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
On the Profile page, in the Language section, the link "Here's how to help us" pointed to a page that displays an error message "Oops! That page doesn't exist or is private."

#### Checklist

Before merging this PR, the following things must have been done:

- [X] Faithful integration of the mockups at all screen sizes
- [X] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [X] Localized in english and french
- [X] All changes have test coverage
- [X] Updated README, if necessary
