### PR TITLE
Add konnectors to permissions page

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -47,6 +47,11 @@
       "type": "io.cozy.apps",
       "verbs": ["GET", "POST", "PUT"]
     },
+     "konnectors": {
+      "description": "Required to get the list of konnectors",
+      "type": "io.cozy.konnectors",
+      "verbs": ["GET"]
+    },
     "accounts": {
       "description": "Required to manage accounts associated to konnectors",
       "type": "io.cozy.accounts",

--- a/src/containers/Permission.jsx
+++ b/src/containers/Permission.jsx
@@ -41,7 +41,9 @@ const Permission = ({ match }) => {
               .verbs ? (
               queryResult.data[0].attributes.permissions[
                 permissionName
-              ].verbs.map((el, i) => <ListItemText key={i}>{el}</ListItemText>)
+              ].verbs.map(permission => (
+                <ListItemText key={permission.name}>{permission}</ListItemText>
+              ))
             ) : (
               <ListItemText>ALL</ListItemText>
             )}

--- a/src/containers/Permissions.jsx
+++ b/src/containers/Permissions.jsx
@@ -22,13 +22,14 @@ import CozyClient, {
 
 const Permissions = () => {
   const { t } = useI18n()
+  const THIRTY_SECONDS = 30 * 1000
   const queryResultApps = useQuery(Q(APPS_DOCTYPE), {
     as: APPS_DOCTYPE,
-    fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS)
   })
   const queryResultKonnectors = useQuery(Q(KONNECTORS_DOCTYPE), {
     as: KONNECTORS_DOCTYPE,
-    fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS)
   })
 
   return (
@@ -49,14 +50,14 @@ const Permissions = () => {
           {queryResultApps.data
             .concat(queryResultKonnectors.data)
             .sort((a, b) => a.slug.localeCompare(b.slug))
-            .map(el => (
-              <div key={el.name}>
-                <Link to={'/permissions/' + el.slug}>
+            .map(appOrKonnector => (
+              <div key={appOrKonnector.name}>
+                <Link to={'/permissions/' + appOrKonnector.slug}>
                   <ListItem button>
                     <ListItemIcon>
-                      <AppIcon app={el} />
+                      <AppIcon app={appOrKonnector} />
                     </ListItemIcon>
-                    <ListItemText primary={el.name} />
+                    <ListItemText primary={appOrKonnector.name} />
                   </ListItem>
                 </Link>
                 <Divider />

--- a/src/containers/Permissions.jsx
+++ b/src/containers/Permissions.jsx
@@ -12,7 +12,7 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { APPS_DOCTYPE } from 'doctypes'
+import { APPS_DOCTYPE, KONNECTORS_DOCTYPE } from 'doctypes'
 import CozyClient, {
   Q,
   useQuery,
@@ -22,35 +22,46 @@ import CozyClient, {
 
 const Permissions = () => {
   const { t } = useI18n()
-  const queryResult = useQuery(Q(APPS_DOCTYPE), {
+  const queryResultApps = useQuery(Q(APPS_DOCTYPE), {
     as: APPS_DOCTYPE,
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+  })
+  const queryResultKonnectors = useQuery(Q(KONNECTORS_DOCTYPE), {
+    as: KONNECTORS_DOCTYPE,
     fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
   })
 
   return (
     <Page narrow>
       <PageTitle>{t('Permissions.title')}</PageTitle>
-      {isQueryLoading(queryResult) && !hasQueryBeenLoaded(queryResult) ? (
+      {(isQueryLoading(queryResultApps) ||
+        isQueryLoading(queryResultKonnectors)) &&
+      (!hasQueryBeenLoaded(queryResultApps) ||
+        !hasQueryBeenLoaded(queryResultKonnectors)) ? (
         <Spinner size="large" className="u-flex u-flex-justify-center u-mt-1" />
-      ) : queryResult.fetchStatus === 'failed' ? (
+      ) : (queryResultApps.fetchStatus || queryResultKonnectors.fetchStatus) ===
+        'failed' ? (
         <Typography variant="body1" className="u-mb-1-half">
           {t('Permissions.failedRequest')}
         </Typography>
       ) : (
         <List>
-          {queryResult.data.map(app => (
-            <div key={app.name}>
-              <Link to={'/permissions/' + app.slug}>
-                <ListItem button>
-                  <ListItemIcon>
-                    <AppIcon app={app} />
-                  </ListItemIcon>
-                  <ListItemText primary={app.name} />
-                </ListItem>
-              </Link>
-              <Divider />
-            </div>
-          ))}
+          {queryResultApps.data
+            .concat(queryResultKonnectors.data)
+            .sort((a, b) => a.slug.localeCompare(b.slug))
+            .map(el => (
+              <div key={el.name}>
+                <Link to={'/permissions/' + el.slug}>
+                  <ListItem button>
+                    <ListItemIcon>
+                      <AppIcon app={el} />
+                    </ListItemIcon>
+                    <ListItemText primary={el.name} />
+                  </ListItem>
+                </Link>
+                <Divider />
+              </div>
+            ))}
         </List>
       )}
     </Page>

--- a/src/containers/Permissions.spec.jsx
+++ b/src/containers/Permissions.spec.jsx
@@ -1,0 +1,133 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import Permissions from './Permissions'
+import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
+
+jest.mock('cozy-ui/transpiled/react', () => {
+  return { useI18n: () => ({ t: x => x }) }
+})
+
+jest.mock('react-router-dom', () => {
+  return {
+    Link: ({ narrow, children }) => (
+      <div data-testid="page" data-narrow={narrow}>
+        {children}
+      </div>
+    )
+  }
+})
+
+jest.mock('cozy-client')
+
+jest.mock('components/Page', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ narrow, children }) => (
+    <div data-testid="page" data-narrow={narrow}>
+      {children}
+    </div>
+  )
+})
+
+jest.mock('components/PageTitle', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ children }) => <div data-testid="page-title">{children}</div>
+})
+
+jest.mock('cozy-ui/transpiled/react/Spinner', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ size }) => <div data-testid="Spinner" data-size={size}></div>
+})
+
+jest.mock('cozy-ui/transpiled/react/AppIcon', () => {
+  // eslint-disable-next-line react/display-name
+  return () => <div data-testid="AppIcon"></div>
+})
+
+describe('Permissions', () => {
+  beforeEach(() => {
+    const queryResultApps = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                description: 'Required to access the files'
+              },
+              allFiles: {
+                type: 'io.cozy.files.*',
+                description: 'Required to access the files'
+              },
+              apps: {
+                type: 'io.cozy.apps',
+                description:
+                  'Required by the cozy-bar to display the icons of the apps',
+                verbs: ['GET']
+              }
+            }
+          },
+          slug: 'contacts',
+          name: 'Contacts'
+        }
+      ]
+    }
+    const queryResultKonnectors = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                description: 'Required to access the files'
+              },
+              allFiles: {
+                type: 'io.cozy.files.*',
+                description: 'Required to access the files'
+              },
+              konnectors: {
+                description: 'Required to get the list of konnectors',
+                type: 'io.cozy.konnectors',
+                verbs: ['GET']
+              }
+            }
+          },
+          slug: 'alan',
+          name: 'Alan'
+        }
+      ]
+    }
+    isQueryLoading.mockReturnValue(true)
+    hasQueryBeenLoaded.mockReturnValue(true)
+    Q.mockReturnValue({ getById: () => 'kfrf' })
+    useQuery.mockReturnValueOnce(queryResultApps)
+    useQuery.mockReturnValueOnce(queryResultKonnectors)
+  })
+  it('should display appName when query has been loaded', () => {
+    hasQueryBeenLoaded.mockReturnValue(true)
+    const { container } = render(<Permissions />)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render a spinner when query is loading and has not been loaded', () => {
+    isQueryLoading.mockReturnValue(true)
+    hasQueryBeenLoaded.mockReturnValue(false)
+    const { queryByTestId } = render(<Permissions />)
+    expect(queryByTestId('Spinner')).toBeTruthy()
+  })
+
+  it('should display appName and konnectorName when query is not loading', () => {
+    isQueryLoading.mockReturnValue(false)
+    const { queryByText } = render(<Permissions />)
+    expect(queryByText('Contacts')).toBeTruthy()
+    expect(queryByText('Alan')).toBeTruthy()
+  })
+
+  it('should render Permissions.failedRequest when query status is failed', () => {
+    useQuery.mockReset()
+    useQuery.mockReturnValue({ fetchStatus: 'failed' })
+    const { queryByText } = render(<Permissions />)
+    expect(queryByText('Permissions.failedRequest')).toBeTruthy()
+  })
+})

--- a/src/containers/__snapshots__/Permissions.spec.jsx.snap
+++ b/src/containers/__snapshots__/Permissions.spec.jsx.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Permissions should display appName when query has been loaded 1`] = `
+<div>
+  <div
+    data-narrow="true"
+    data-testid="page"
+  >
+    <div
+      data-testid="page-title"
+    >
+      Permissions.title
+    </div>
+    <ul
+      class="MuiList-root MuiList-padding"
+    >
+      <div>
+        <div
+          data-testid="page"
+        >
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root"
+            >
+              <div
+                data-testid="AppIcon"
+              />
+            </div>
+            <div
+              class="MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root u-db u-ellipsis MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Alan
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <hr
+          class="MuiDivider-root"
+        />
+      </div>
+      <div>
+        <div
+          data-testid="page"
+        >
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root"
+            >
+              <div
+                data-testid="AppIcon"
+              />
+            </div>
+            <div
+              class="MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root u-db u-ellipsis MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Contacts
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <hr
+          class="MuiDivider-root"
+        />
+      </div>
+    </ul>
+  </div>
+</div>
+`;

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -1,1 +1,2 @@
 export const APPS_DOCTYPE = 'io.cozy.apps'
+export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'


### PR DESCRIPTION
First commit : This fix should have been in github.com/https://github.com/cozy/cozy-settings/pull/414
Second commit : Add konnectors to permissions page and alphabetical sort on applications/konnectors name

<img width="680" alt="Capture d’écran 2022-07-19 à 15 16 16" src="https://user-images.githubusercontent.com/61142137/179759582-d1b6c950-5c9a-4579-9842-13172439a435.png">
