### PR TITLE
Display permissions type details

### DIFF
--- a/src/containers/Permission.spec.jsx
+++ b/src/containers/Permission.spec.jsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import PermissionsApplication from './PermissionsApplication'
+import Permission from './Permission'
 import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
 
 jest.mock('cozy-ui/transpiled/react', () => {
@@ -10,7 +10,7 @@ jest.mock('cozy-ui/transpiled/react', () => {
 jest.mock('react-router-dom', () => {
   return {
     withRouter: Component => {
-      const match = { params: { app: 'Drive' } }
+      const match = { params: { app: 'Drive', permission: 'apps' } }
       // eslint-disable-next-line react/display-name
       return () => <Component match={match} />
     },
@@ -35,18 +35,14 @@ jest.mock('components/Page', () => {
   )
 })
 
-jest.mock('components/PageTitle', () => {
-  // eslint-disable-next-line react/display-name
-  return ({ children }) => <div data-testid="pageTitle">{children}</div>
-})
 jest.mock('cozy-ui/transpiled/react/Spinner', () => {
   // eslint-disable-next-line react/display-name
   return ({ size }) => <div data-testid="Spinner" data-size={size}></div>
 })
 
-describe('PermissionsApplication', () => {
+describe('Permission', () => {
   beforeEach(() => {
-    const queryResult = {
+    const queryResultApps = {
       fetchStatus: 'loaded',
       data: [
         {
@@ -65,45 +61,59 @@ describe('PermissionsApplication', () => {
                 description:
                   'Required by the cozy-bar to display the icons of the apps',
                 verbs: ['GET']
-              },
-              findABetterNamePlease: {
-                type: 'io.cozy.apps',
-                description:
-                  'Required by the cozy-bar to display the icons of the apps',
-                verbs: ['POST']
               }
             }
-          }
+          },
+          slug: 'contacts',
+          name: 'Contacts'
+        }
+      ]
+    }
+    const queryResultKonnectors = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                description: 'Required to access the files'
+              },
+              allFiles: {
+                type: 'io.cozy.files.*',
+                description: 'Required to access the files'
+              },
+              konnectors: {
+                description: 'Required to get the list of konnectors',
+                type: 'io.cozy.konnectors',
+                verbs: ['GET']
+              }
+            }
+          },
+          slug: 'alan',
+          name: 'Alan'
         }
       ]
     }
     isQueryLoading.mockReturnValue(true)
     hasQueryBeenLoaded.mockReturnValue(true)
     Q.mockReturnValue({ getById: () => 'kfrf' })
-    useQuery.mockReturnValue(queryResult)
+    useQuery.mockReturnValueOnce(queryResultApps)
+    useQuery.mockReturnValueOnce(queryResultKonnectors)
+    useQuery.mockReturnValueOnce(queryResultApps)
+    useQuery.mockReturnValueOnce(queryResultKonnectors)
   })
+
   it('should display appName when query has been loaded', () => {
     hasQueryBeenLoaded.mockReturnValue(true)
-    const { container } = render(<PermissionsApplication />)
+    const { container } = render(<Permission />)
     expect(container).toMatchSnapshot()
   })
 
   it('should render a spinner when query is loading and has not been loaded', () => {
     isQueryLoading.mockReturnValue(true)
     hasQueryBeenLoaded.mockReturnValue(false)
-    const { queryByTestId } = render(<PermissionsApplication />)
+    const { queryByTestId } = render(<Permission />)
     expect(queryByTestId('Spinner')).toBeTruthy()
-  })
-
-  it('should display appName when query is not loading', () => {
-    isQueryLoading.mockReturnValue(false)
-    const { queryByText } = render(<PermissionsApplication />)
-    expect(queryByText('DRIVE')).toBeTruthy()
-  })
-
-  it('should render Permissions.failedRequest when query status is failed', () => {
-    useQuery.mockReturnValue({ fetchStatus: 'failed' })
-    const { queryByText } = render(<PermissionsApplication />)
-    expect(queryByText('Permissions.failedRequest')).toBeTruthy()
   })
 })

--- a/src/containers/PermissionsApplication.jsx
+++ b/src/containers/PermissionsApplication.jsx
@@ -13,6 +13,7 @@ import { useI18n } from 'cozy-ui/transpiled/react'
 import Page from 'components/Page'
 import PageTitle from 'components/PageTitle'
 import { withRouter, Link } from 'react-router-dom'
+import { displayPermissions } from './helpers/permissionsHelper'
 
 const PermissionsApplication = ({ match }) => {
   const { t } = useI18n()
@@ -57,7 +58,7 @@ const PermissionsApplication = ({ match }) => {
           ).map(([key, value]) => (
             <Link to={`/permissions/${appName}/${key}`} key={key}>
               <Typography variant="h4">
-                {value.type} : {value.verbs ? value.verbs.join(' / ') : 'ALL'}
+                {value.type} : {displayPermissions(value.verbs)}
               </Typography>
             </Link>
           ))}

--- a/src/containers/PermissionsApplication.spec.jsx
+++ b/src/containers/PermissionsApplication.spec.jsx
@@ -66,10 +66,9 @@ describe('PermissionsApplication', () => {
                   'Required by the cozy-bar to display the icons of the apps',
                 verbs: ['GET']
               },
-              findABetterNamePlease: {
-                type: 'io.cozy.apps',
-                description:
-                  'Required by the cozy-bar to display the icons of the apps',
+              accounts: {
+                type: 'io.cozy.accounts',
+                description: 'Required to access accounts',
                 verbs: ['POST']
               }
             }

--- a/src/containers/__snapshots__/Permission.spec.jsx.snap
+++ b/src/containers/__snapshots__/Permission.spec.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Permission should display appName when query has been loaded 1`] = `
+<div>
+  <div
+    data-narrow="true"
+    data-testid="page"
+  >
+    <div>
+      <h1
+        class="MuiTypography-root MuiTypography-h1"
+      >
+        Application: 
+        DRIVE
+      </h1>
+      <h2
+        class="MuiTypography-root MuiTypography-h2"
+      >
+        Permission: 
+        apps
+      </h2>
+      <h3
+        class="MuiTypography-root MuiTypography-h3"
+      >
+        Lecture
+      </h3>
+    </div>
+  </div>
+</div>
+`;

--- a/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
+++ b/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
@@ -50,12 +50,12 @@ exports[`PermissionsApplication should display appName when query has been loade
       </div>
       <div
         data-testid="Link"
-        data-to="/permissions/Drive/findABetterNamePlease"
+        data-to="/permissions/Drive/accounts"
       >
         <h4
           class="MuiTypography-root MuiTypography-h4"
         >
-          io.cozy.apps
+          io.cozy.accounts
            : 
           Écriture
         </h4>

--- a/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
+++ b/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`PermissionsApplication should display appName when query has been loade
         >
           io.cozy.files
            : 
-          ALL
+          Lecture et Écriture
         </h4>
       </div>
       <div
@@ -33,7 +33,7 @@ exports[`PermissionsApplication should display appName when query has been loade
         >
           io.cozy.files.*
            : 
-          ALL
+          Lecture et Écriture
         </h4>
       </div>
       <div
@@ -45,7 +45,19 @@ exports[`PermissionsApplication should display appName when query has been loade
         >
           io.cozy.apps
            : 
-          GET
+          Lecture
+        </h4>
+      </div>
+      <div
+        data-testid="Link"
+        data-to="/permissions/Drive/findABetterNamePlease"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          io.cozy.apps
+           : 
+          Écriture
         </h4>
       </div>
     </div>

--- a/src/containers/helpers/permissionsHelper.js
+++ b/src/containers/helpers/permissionsHelper.js
@@ -1,0 +1,7 @@
+export const displayPermissions = verbs => {
+  return !verbs || (verbs.length > 1 && verbs.includes('GET'))
+    ? 'Lecture et Écriture'
+    : verbs.length === 1 && verbs.includes('GET')
+    ? 'Lecture'
+    : 'Écriture'
+}

--- a/src/containers/helpers/permissionsHelper.spec.js
+++ b/src/containers/helpers/permissionsHelper.spec.js
@@ -1,0 +1,20 @@
+import { displayPermissions } from './permissionsHelper'
+
+describe('displayPermissions', () => {
+  it('should return Lecture et Écriture when verbs is undefined', () => {
+    const result = displayPermissions(undefined)
+    expect(result).toEqual('Lecture et Écriture')
+  })
+  it('should return Lecture et Écriture when several verbs including GET ', () => {
+    const result = displayPermissions(['GET', 'POST', 'PUT'])
+    expect(result).toEqual('Lecture et Écriture')
+  })
+  it('should return Lecture when verbs contains only GET ', () => {
+    const result = displayPermissions(['GET'])
+    expect(result).toEqual('Lecture')
+  })
+  it('should return Ecriture when verbs does not contain GET ', () => {
+    const result = displayPermissions(['POST', 'PUT', 'DELETE'])
+    expect(result).toEqual('Écriture')
+  })
+})


### PR DESCRIPTION
1: On an app / konnector permissions list, display 'Read' / 'Write' or both instead of verbs
2: Bug fixed: If a permission of a konnector was clicked, 'Failed request' was displayed instead of the verbs
3: When a permission of an app or a konnector is clicked, verbs replaced  by details ( 'Read' / 'Write' / both)
<img width="483" alt="Capture d’écran 2022-07-27 à 11 01 04" src="https://user-images.githubusercontent.com/61142137/181207537-0ab75aff-a889-444d-8e4b-60d565c2268e.png">
<img width="611" alt="Capture d’écran 2022-07-27 à 11 01 28" src="https://user-images.githubusercontent.com/61142137/181207543-91e678ef-7e0c-45db-9d18-3bd935ee6c93.png">
