### PR TITLE
 feat(Permissions): Display permissions type details instead of verbs

### DIFF
--- a/src/containers/Permission.jsx
+++ b/src/containers/Permission.jsx
@@ -1,32 +1,72 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
-import { APPS_DOCTYPE } from 'doctypes'
+import { APPS_DOCTYPE, KONNECTORS_DOCTYPE } from 'doctypes'
 import { withRouter } from 'react-router-dom'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
+import CozyClient, {
+  Q,
+  useQuery,
+  isQueryLoading,
+  hasQueryBeenLoaded
+} from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react'
 import Page from 'components/Page'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
-import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { displayPermissions } from './helpers/permissionsHelper'
 
 const Permission = ({ match }) => {
   const { t } = useI18n()
   const appName = match.params.app
   const permissionName = match.params.permission
+  const THIRTY_SECONDS = 30 * 1000
 
-  const queryResult = useQuery(
+  const [verbs, setVerbs] = useState([])
+
+  // TODO : instead of sending 2 queries (queryResultApps & queryResultKonnectors) where 1 will be useless, find a way to check if we have an app or a konnector and send only 1 query
+  const queryResultApps = useQuery(
     Q(APPS_DOCTYPE).getById('io.cozy.apps/' + appName),
     {
-      as: 'io.cozy.apps/' + appName
+      as: 'io.cozy.apps/' + appName,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS),
+      singleDocData: true
     }
   )
 
+  const queryResultKonnectors = useQuery(
+    Q(KONNECTORS_DOCTYPE).getById('io.cozy.konnectors/' + appName),
+    {
+      as: 'io.cozy.konnectors/' + appName,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS),
+      singleDocData: true
+    }
+  )
+
+  useEffect(() => {
+    let result
+
+    if (queryResultApps.data) {
+      result = queryResultApps
+    } else if (queryResultKonnectors.data) {
+      result = queryResultKonnectors
+    } else {
+      return
+    }
+
+    const verbs = result.data?.permissions?.[permissionName]?.verbs
+    if (verbs) {
+      setVerbs(verbs)
+    }
+  }, [queryResultApps, queryResultKonnectors, permissionName])
+
   return (
     <Page narrow>
-      {isQueryLoading(queryResult) && !hasQueryBeenLoaded(queryResult) ? (
+      {(isQueryLoading(queryResultApps) &&
+        !hasQueryBeenLoaded(queryResultApps)) ||
+      (isQueryLoading(queryResultKonnectors) &&
+        !hasQueryBeenLoaded(queryResultKonnectors)) ? (
         <Spinner size="large" className="u-flex u-flex-justify-center u-mt-1" />
-      ) : queryResult.fetchStatus === 'failed' ? (
+      ) : queryResultApps.fetchStatus === 'failed' &&
+        queryResultKonnectors.fetchStatus === 'failed' ? (
         <Typography variant="body1" className="u-mb-1-half">
           {t('Permissions.failedRequest')}
         </Typography>
@@ -36,18 +76,7 @@ const Permission = ({ match }) => {
             Application: {appName.toUpperCase()}
           </Typography>
           <Typography variant="h2">Permission: {permissionName}</Typography>
-          <List>
-            {queryResult.data[0].attributes.permissions[permissionName]
-              .verbs ? (
-              queryResult.data[0].attributes.permissions[
-                permissionName
-              ].verbs.map(permission => (
-                <ListItemText key={permission.name}>{permission}</ListItemText>
-              ))
-            ) : (
-              <ListItemText>ALL</ListItemText>
-            )}
-          </List>
+          <Typography variant="h3">{t(displayPermissions(verbs))}</Typography>
         </div>
       )}
     </Page>

--- a/src/containers/Permission.spec.jsx
+++ b/src/containers/Permission.spec.jsx
@@ -1,0 +1,119 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import Permission from './Permission'
+import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
+
+jest.mock('cozy-ui/transpiled/react', () => {
+  return { useI18n: () => ({ t: x => x }) }
+})
+
+jest.mock('react-router-dom', () => {
+  return {
+    withRouter: Component => {
+      const match = { params: { app: 'Drive', permission: 'apps' } }
+      // eslint-disable-next-line react/display-name
+      return () => <Component match={match} />
+    },
+    Link:
+      // eslint-disable-next-line react/display-name
+      ({ to, children }) => (
+        <div data-testid="Link" data-to={to}>
+          {children}
+        </div>
+      )
+  }
+})
+
+jest.mock('cozy-client')
+
+jest.mock('components/Page', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ narrow, children }) => (
+    <div data-testid="page" data-narrow={narrow}>
+      {children}
+    </div>
+  )
+})
+
+jest.mock('cozy-ui/transpiled/react/Spinner', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ size }) => <div data-testid="Spinner" data-size={size}></div>
+})
+
+describe('Permission', () => {
+  beforeEach(() => {
+    const queryResultApps = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                description: 'Required to access the files'
+              },
+              allFiles: {
+                type: 'io.cozy.files.*',
+                description: 'Required to access the files'
+              },
+              apps: {
+                type: 'io.cozy.apps',
+                description:
+                  'Required by the cozy-bar to display the icons of the apps',
+                verbs: ['GET']
+              }
+            }
+          },
+          slug: 'contacts',
+          name: 'Contacts'
+        }
+      ]
+    }
+    const queryResultKonnectors = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          attributes: {
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                description: 'Required to access the files'
+              },
+              allFiles: {
+                type: 'io.cozy.files.*',
+                description: 'Required to access the files'
+              },
+              konnectors: {
+                description: 'Required to get the list of konnectors',
+                type: 'io.cozy.konnectors',
+                verbs: ['GET']
+              }
+            }
+          },
+          slug: 'alan',
+          name: 'Alan'
+        }
+      ]
+    }
+    isQueryLoading.mockReturnValue(true)
+    hasQueryBeenLoaded.mockReturnValue(true)
+    Q.mockReturnValue({ getById: () => 'kfrf' })
+    useQuery.mockReturnValueOnce(queryResultApps)
+    useQuery.mockReturnValueOnce(queryResultKonnectors)
+    useQuery.mockReturnValueOnce(queryResultApps)
+    useQuery.mockReturnValueOnce(queryResultKonnectors)
+  })
+
+  it('should display appName when query has been loaded', () => {
+    hasQueryBeenLoaded.mockReturnValue(true)
+    const { container } = render(<Permission />)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render a spinner when query is loading and has not been loaded', () => {
+    isQueryLoading.mockReturnValue(true)
+    hasQueryBeenLoaded.mockReturnValue(false)
+    const { queryByTestId } = render(<Permission />)
+    expect(queryByTestId('Spinner')).toBeTruthy()
+  })
+})

--- a/src/containers/PermissionsApplication.jsx
+++ b/src/containers/PermissionsApplication.jsx
@@ -6,7 +6,7 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import Page from 'components/Page'
 import PageTitle from 'components/PageTitle'
 import { withRouter, Link } from 'react-router-dom'
-import withLocales from 'lib/withLocales'
+import { displayPermissions } from './helpers/permissionsHelper'
 
 import CozyClient, {
   Q,
@@ -14,6 +14,7 @@ import CozyClient, {
   isQueryLoading,
   hasQueryBeenLoaded
 } from 'cozy-client'
+import withAllLocales from '../lib/withAllLocales'
 
 export const completePermission = (
   name,
@@ -62,7 +63,7 @@ const PermissionsApplication = ({ match, t }) => {
   const sortPermissionsByName = queryResult => {
     return Object.entries(queryResult.data[0].attributes.permissions)
       .map(([name, value]) => {
-        const perm = t('Permissions.' + value.type)
+        const perm = t('CozyClient.Permissions.' + value.type)
         return completePermission(name, perm, value)
       })
       .sort((a, b) => {
@@ -88,7 +89,7 @@ const PermissionsApplication = ({ match, t }) => {
             ({ name, title, verbs }) => (
               <Link to={`/permissions/${appName}/${name}`} key={name}>
                 <Typography variant="h4">
-                  {title} : {verbs ? verbs.join(' / ') : 'ALL'}
+                  {title} : {t(displayPermissions(verbs))}
                 </Typography>
               </Link>
             )
@@ -99,4 +100,4 @@ const PermissionsApplication = ({ match, t }) => {
   )
 }
 
-export default withRouter(withLocales(PermissionsApplication))
+export default withRouter(withAllLocales(PermissionsApplication))

--- a/src/containers/PermissionsApplication.spec.jsx
+++ b/src/containers/PermissionsApplication.spec.jsx
@@ -14,6 +14,10 @@ jest.mock('cozy-ui/transpiled/react/I18n/withLocales', () => {
   }
 })
 
+jest.mock('cozy-ui/transpiled/react', () => ({
+  useI18n: () => ({ t: text => text })
+}))
+
 jest.mock('react-router-dom', () => {
   return {
     withRouter: Component => Component,
@@ -72,6 +76,11 @@ describe('PermissionsApplication', () => {
                 description:
                   'Required by the cozy-bar to display the icons of the apps',
                 verbs: ['GET']
+              },
+              accounts: {
+                type: 'io.cozy.accounts',
+                description: 'Required to access accounts',
+                verbs: ['POST']
               }
             }
           }

--- a/src/containers/__snapshots__/Permission.spec.jsx.snap
+++ b/src/containers/__snapshots__/Permission.spec.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Permission should display appName when query has been loaded 1`] = `
+<div>
+  <div
+    data-narrow="true"
+    data-testid="page"
+  >
+    <div>
+      <h1
+        class="MuiTypography-root MuiTypography-h1"
+      >
+        Application: 
+        DRIVE
+      </h1>
+      <h2
+        class="MuiTypography-root MuiTypography-h2"
+      >
+        Permission: 
+        apps
+      </h2>
+      <h3
+        class="MuiTypography-root MuiTypography-h3"
+      >
+        Permissions.write
+      </h3>
+    </div>
+  </div>
+</div>
+`;

--- a/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
+++ b/src/containers/__snapshots__/PermissionsApplication.spec.jsx.snap
@@ -18,9 +18,9 @@ exports[`PermissionsApplication should display appName when query has been loade
         <h4
           class="MuiTypography-root MuiTypography-h4"
         >
-          Permissions.io.cozy.apps
+          CozyClient.Permissions.io.cozy.accounts
            : 
-          GET
+          Permissions.write
         </h4>
       </div>
       <div
@@ -29,9 +29,9 @@ exports[`PermissionsApplication should display appName when query has been loade
         <h4
           class="MuiTypography-root MuiTypography-h4"
         >
-          Permissions.io.cozy.files
+          CozyClient.Permissions.io.cozy.apps
            : 
-          ALL
+          Permissions.read
         </h4>
       </div>
       <div
@@ -40,9 +40,20 @@ exports[`PermissionsApplication should display appName when query has been loade
         <h4
           class="MuiTypography-root MuiTypography-h4"
         >
-          Permissions.io.cozy.files.*
+          CozyClient.Permissions.io.cozy.files
            : 
-          ALL
+          Permissions.readAndWrite
+        </h4>
+      </div>
+      <div
+        data-testid="page"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          CozyClient.Permissions.io.cozy.files.*
+           : 
+          Permissions.readAndWrite
         </h4>
       </div>
     </div>

--- a/src/containers/helpers/permissionsHelper.js
+++ b/src/containers/helpers/permissionsHelper.js
@@ -1,0 +1,7 @@
+export const displayPermissions = verbs => {
+  return !verbs || (verbs.length > 1 && verbs.includes('GET'))
+    ? 'Permissions.readAndWrite'
+    : verbs.length === 1 && verbs.includes('GET')
+    ? 'Permissions.read'
+    : 'Permissions.write'
+}

--- a/src/containers/helpers/permissionsHelper.spec.js
+++ b/src/containers/helpers/permissionsHelper.spec.js
@@ -1,0 +1,20 @@
+import { displayPermissions } from './permissionsHelper'
+
+describe('displayPermissions', () => {
+  it('should return Lecture et Écriture when verbs is undefined', () => {
+    const result = displayPermissions(undefined)
+    expect(result).toEqual('Permissions.readAndWrite')
+  })
+  it('should return Lecture et Écriture when several verbs including GET ', () => {
+    const result = displayPermissions(['GET', 'POST', 'PUT'])
+    expect(result).toEqual('Permissions.readAndWrite')
+  })
+  it('should return Lecture when verbs contains only GET ', () => {
+    const result = displayPermissions(['GET'])
+    expect(result).toEqual('Permissions.read')
+  })
+  it('should return Ecriture when verbs does not contain GET ', () => {
+    const result = displayPermissions(['POST', 'PUT', 'DELETE'])
+    expect(result).toEqual('Permissions.write')
+  })
+})

--- a/src/lib/withAllLocales.js
+++ b/src/lib/withAllLocales.js
@@ -1,0 +1,15 @@
+import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
+
+const dictRequire = lang => {
+  const cozyClientLocales = require(`cozy-client/dist/models/doctypes/locales/${lang}.json`)
+  const cozySettingsLocales = require(`../locales/${lang}.json`)
+  return { CozyClient: cozyClientLocales, ...cozySettingsLocales }
+}
+
+/**
+ * @function
+ * @description HOC to provide locales from CozyClient and from the application to components.
+ * @param  {Function} Component - Component that need translations from CozyClient
+ * @returns {Function} - Component that will receive translations from CozyClient and CozySettings
+ */
+export default withLocales(dictRequire)

--- a/src/lib/withAllLocales.spec.js
+++ b/src/lib/withAllLocales.spec.js
@@ -1,0 +1,27 @@
+import withAllLocales from './withAllLocales'
+import React from 'react'
+import { render } from '@testing-library/react'
+import { useI18n } from 'cozy-ui/transpiled/react'
+
+describe('withAllLocales', () => {
+  it('should provide translations from CozyClient and CozySettings', () => {
+    // Given
+    let MyComponent = () => {
+      const { t } = useI18n()
+      return (
+        <div>
+          <p>{t('Permissions.write')}</p>
+          <p>{t('CozyClient.Permissions.io.cozy.accounts')}</p>
+        </div>
+      )
+    }
+    const MyTranslatedComponent = withAllLocales(MyComponent)
+
+    // When
+    const { getByText } = render(<MyTranslatedComponent />)
+
+    // Then
+    expect(getByText('Write')).toBeTruthy()
+    expect(getByText('Login details')).toBeTruthy()
+  })
+})

--- a/src/lib/withLocales.js
+++ b/src/lib/withLocales.js
@@ -1,6 +1,0 @@
-import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
-
-const dictRequire = lang =>
-  require(`cozy-client/dist/models/doctypes/locales/${lang}.json`)
-
-export default withLocales(dictRequire)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -398,6 +398,9 @@
   
   "Permissions": {
     "title": "Applications control",
-    "failedRequest": "The request has failed"
+    "failedRequest": "The request has failed",
+    "read": "Read",
+    "readAndWrite": "Read and Write",
+    "write": "Write"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -398,6 +398,9 @@
 
   "Permissions": {
     "title": "Permissions",
-    "failedRequest": "La requête a échoué"
+    "failedRequest": "La requête a échoué",
+    "read": "Lecture",
+    "readAndWrite": "Lecture et Écriture",
+    "write": "Écriture"
   }
 }


### PR DESCRIPTION
1: On an app / konnector permissions list, display 'Read' / 'Write' or both instead of verbs
2: Bug fixed: If a permission of a konnector was clicked, 'Failed request' was displayed instead of the verbs
3: When a permission of an app or a konnector is clicked, verbs replaced by details ( 'Read' / 'Write' / both)
<img width="483" alt="1" src="https://user-images.githubusercontent.com/61142137/182121543-106db0bd-8dec-4ddb-b5e0-89dc81fa1dc8.png">
<img width="611" alt="2" src="https://user-images.githubusercontent.com/61142137/182121555-1e6f76fc-9d48-4e10-9722-a24b95403413.png">
