### PR TITLE
fix: Remove Home, Store and Settings from the list of apps

### DIFF
--- a/src/containers/Permissions.jsx
+++ b/src/containers/Permissions.jsx
@@ -31,6 +31,7 @@ const Permissions = () => {
     as: KONNECTORS_DOCTYPE,
     fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS)
   })
+  const toNotDisplay = ['home', 'store', 'settings']
 
   return (
     <Page narrow>
@@ -50,6 +51,7 @@ const Permissions = () => {
           {queryResultApps.data
             .concat(queryResultKonnectors.data)
             .sort((a, b) => a.slug.localeCompare(b.slug))
+            .filter(a => !toNotDisplay.includes(a.slug))
             .map(appOrKonnector => {
               return (
                 <div key={appOrKonnector.name}>

--- a/src/containers/Permissions.spec.jsx
+++ b/src/containers/Permissions.spec.jsx
@@ -87,6 +87,21 @@ describe('Permissions', () => {
           },
           slug: 'contacts',
           name: 'Contacts'
+        },
+        {
+          permissions: {},
+          slug: 'home',
+          name: 'Home'
+        },
+        {
+          permissions: {},
+          slug: 'settings',
+          name: 'Settings'
+        },
+        {
+          permissions: {},
+          slug: 'store',
+          name: 'Store'
         }
       ]
     }
@@ -133,6 +148,14 @@ describe('Permissions', () => {
       'data-primary',
       'Alan'
     )
+  })
+
+  it('should not display Home, Settings and Store when query is not loading', () => {
+    isQueryLoading.mockReturnValue(false)
+    const { queryByText } = render(<Permissions />)
+    expect(queryByText('Home')).toBeFalsy
+    expect(queryByText('Settings')).toBeFalsy
+    expect(queryByText('Store')).toBeFalsy
   })
 
   it('should render Permissions.failedRequest when query status is failed', () => {


### PR DESCRIPTION
When the user uses his Cozy, he does not see the home, settings or the store as applications but as the Cozy platform. Technically they are definitely apps but they are not seen as such functionally. That's why they should not be displayed