### PR TITLE
feat: Add tab to display DataList

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -18,7 +18,7 @@ import Devices from 'containers/Devices'
 import Sessions from 'containers/Sessions'
 import Storage from 'containers/Storage'
 import Passphrase from 'containers/Passphrase'
-import Permissions from 'containers/Permissions'
+import PermissionsTab from './Permissions/PermissionsTab'
 import IntentRedirect from 'services/IntentRedirect'
 import PermissionsApplication from 'containers/PermissionsApplication'
 import Permission from 'containers/Permission'
@@ -44,18 +44,19 @@ export class App extends Component {
             <Route path="/connectedDevices/:deviceId" component={Devices} />
             <Route path="/sessions" component={Sessions} />
             <Route path="/storage" component={Storage} />
-            <Route exact path="/permissions" component={Permissions} />
+            <Route exact path="/permissions/:page" component={PermissionsTab} />
             <Route
               exact
-              path="/permissions/:app"
+              path="/permissions/slug/:app"
               component={PermissionsApplication}
             />
             <Route
-              path="/permissions/:app/:permission"
+              path="/permissions/slug/:app/:permission"
               component={Permission}
             />
             <Route path="/exports/:exportId" component={Profile} />
             <Redirect exact from="/" to="/profile" />
+            <Redirect exact from="/permissions" to="/permissions/slug" />
             <Redirect from="*" to="/profile" />
           </Switch>
         </Main>

--- a/src/components/Permissions/AppList.jsx
+++ b/src/components/Permissions/AppList.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import Page from 'components/Page'
 import PageTitle from 'components/PageTitle'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import { useI18n } from 'cozy-ui/transpiled/react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -11,6 +11,7 @@ import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { routes } from 'constants/routes'
 
 import { APPS_DOCTYPE, KONNECTORS_DOCTYPE } from 'doctypes'
 import CozyClient, {
@@ -20,7 +21,7 @@ import CozyClient, {
   hasQueryBeenLoaded
 } from 'cozy-client'
 
-const Permissions = () => {
+const AppList = () => {
   const { t } = useI18n()
   const THIRTY_SECONDS = 30 * 1000
   const queryResultApps = useQuery(Q(APPS_DOCTYPE), {
@@ -35,7 +36,7 @@ const Permissions = () => {
 
   return (
     <Page narrow>
-      <PageTitle>{t('Permissions.title')}</PageTitle>
+      <PageTitle>{t('Permissions.applications')}</PageTitle>
       {(isQueryLoading(queryResultApps) ||
         isQueryLoading(queryResultKonnectors)) &&
       (!hasQueryBeenLoaded(queryResultApps) ||
@@ -55,7 +56,7 @@ const Permissions = () => {
             .map(appOrKonnector => {
               return (
                 <div key={appOrKonnector.name}>
-                  <Link to={'/permissions/' + appOrKonnector.slug}>
+                  <Link to={`${routes.appList}/${appOrKonnector.slug}`}>
                     <ListItem button>
                       <ListItemIcon>
                         <AppIcon app={appOrKonnector} />
@@ -80,4 +81,4 @@ const Permissions = () => {
   )
 }
 
-export default Permissions
+export default AppList

--- a/src/components/Permissions/AppList.spec.jsx
+++ b/src/components/Permissions/AppList.spec.jsx
@@ -1,20 +1,8 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import Permissions from './Permissions'
+import AppList from './AppList'
 import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
-
-jest.mock('cozy-ui/transpiled/react', () => {
-  return {
-    useI18n: () => ({
-      t: (x, { smart_count } = {}) => {
-        if (smart_count) {
-          return `${x} ${smart_count}`
-        }
-        return x
-      }
-    })
-  }
-})
+import AppLike from 'test/AppLike'
 
 jest.mock('react-router-dom', () => {
   return {
@@ -63,7 +51,7 @@ jest.mock('cozy-ui/transpiled/react/ListItemText', () => {
   )
 })
 
-describe('Permissions', () => {
+describe('AppList', () => {
   beforeEach(() => {
     const queryResultApps = {
       fetchStatus: 'loaded',
@@ -125,20 +113,32 @@ describe('Permissions', () => {
   })
   it('should display appName when query has been loaded', () => {
     hasQueryBeenLoaded.mockReturnValue(true)
-    const { container } = render(<Permissions />)
+    const { container } = render(
+      <AppLike>
+        <AppList />
+      </AppLike>
+    )
     expect(container).toMatchSnapshot()
   })
 
   it('should render a spinner when query is loading and has not been loaded', () => {
     isQueryLoading.mockReturnValue(true)
     hasQueryBeenLoaded.mockReturnValue(false)
-    const { queryByTestId } = render(<Permissions />)
+    const { queryByTestId } = render(
+      <AppLike>
+        <AppList />
+      </AppLike>
+    )
     expect(queryByTestId('Spinner')).toBeTruthy()
   })
 
   it('should display sorted app and konnector names when query is not loading', () => {
     isQueryLoading.mockReturnValue(false)
-    const { getAllByTestId, container } = render(<Permissions />)
+    const { getAllByTestId, container } = render(
+      <AppLike>
+        <AppList />
+      </AppLike>
+    )
     expect(container).toMatchSnapshot()
     expect(getAllByTestId('ListItemText')[1]).toHaveAttribute(
       'data-primary',
@@ -152,7 +152,11 @@ describe('Permissions', () => {
 
   it('should not display Home, Settings and Store when query is not loading', () => {
     isQueryLoading.mockReturnValue(false)
-    const { queryByText } = render(<Permissions />)
+    const { queryByText } = render(
+      <AppLike>
+        <AppList />
+      </AppLike>
+    )
     expect(queryByText('Home')).toBeFalsy
     expect(queryByText('Settings')).toBeFalsy
     expect(queryByText('Store')).toBeFalsy
@@ -161,7 +165,11 @@ describe('Permissions', () => {
   it('should render Permissions.failedRequest when query status is failed', () => {
     useQuery.mockReset()
     useQuery.mockReturnValue({ fetchStatus: 'failed' })
-    const { queryByText } = render(<Permissions />)
-    expect(queryByText('Permissions.failedRequest')).toBeTruthy()
+    const { queryByText } = render(
+      <AppLike>
+        <AppList />
+      </AppLike>
+    )
+    expect(queryByText('The request has failed')).toBeTruthy()
   })
 })

--- a/src/components/Permissions/DataList.jsx
+++ b/src/components/Permissions/DataList.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import Page from 'components/Page'
+import PageTitle from 'components/PageTitle'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+const DataList = () => {
+  const { t } = useI18n()
+  return (
+    <Page narrow>
+      <PageTitle>{t('Permissions.data')}</PageTitle>
+    </Page>
+  )
+}
+
+export default DataList

--- a/src/components/Permissions/DataList.spec.jsx
+++ b/src/components/Permissions/DataList.spec.jsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import DataList from './DataList'
+import AppLike from 'test/AppLike'
+
+jest.mock('cozy-ui/transpiled/react', () => {
+  return { useI18n: () => ({ t: x => x }) }
+})
+
+jest.mock('components/Page', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ narrow, children }) => (
+    <div data-testid="page" data-narrow={narrow}>
+      {children}
+    </div>
+  )
+})
+
+jest.mock('components/PageTitle', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ children }) => <div data-testid="page-title">{children}</div>
+})
+
+describe('DataList', () => {
+  it('should display DataList title', () => {
+    const { queryByText, container } = render(
+      <AppLike>
+        <DataList />
+      </AppLike>
+    )
+    expect(container).toMatchSnapshot()
+    expect(queryByText('Data')).toBeTruthy()
+  })
+})

--- a/src/components/Permissions/PermissionsTab.jsx
+++ b/src/components/Permissions/PermissionsTab.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import Page from 'components/Page'
+import { Tabs, Tab } from 'cozy-ui/transpiled/react/MuiTabs'
+import AppList from './AppList'
+import DataList from './DataList'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider/index'
+import { routes } from 'constants/routes'
+import { withRouter } from 'react-router-dom'
+import withAllLocales from '../../lib/withAllLocales'
+
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`
+  }
+}
+const TabPanel = props => {
+  const { children, value, index, ...other } = props
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && children}
+    </div>
+  )
+}
+const PermissionsTab = ({ match, t }) => {
+  const slugOrData = match.params.page
+  const [tab, setTab] = useState(slugOrData)
+  const handleChange = (event, value) => setTab(value)
+
+  return (
+    <Page narrow>
+      <Tabs value={tab} onChange={handleChange}>
+        <Tab
+          value="slug"
+          label={t('Permissions.applications')}
+          href={`#${routes.appList}`}
+          {...a11yProps(0)}
+        />
+        <Tab
+          value="data"
+          label={t('Permissions.data')}
+          href={`#${routes.dataList}`}
+          {...a11yProps(1)}
+        />
+      </Tabs>
+      <Divider className="u-mb-1" />
+      <TabPanel value={tab} index="slug">
+        <AppList />
+      </TabPanel>
+      <TabPanel value={tab} index="data">
+        <DataList />
+      </TabPanel>
+    </Page>
+  )
+}
+
+export default withRouter(withAllLocales(PermissionsTab))

--- a/src/components/Permissions/PermissionsTab.spec.jsx
+++ b/src/components/Permissions/PermissionsTab.spec.jsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import PermissionsTab from './PermissionsTab'
+
+jest.mock('cozy-ui/transpiled/react/I18n/withLocales', () => {
+  return () => Component => {
+    const t = text => text
+    const match = { params: { page: 'slug' } }
+    // eslint-disable-next-line react/display-name
+    return () => <Component match={match} t={t} />
+  }
+})
+
+jest.mock('react-router-dom', () => {
+  return {
+    withRouter: Component => Component
+  }
+})
+
+jest.mock('cozy-client')
+
+jest.mock('cozy-ui/transpiled/react/MuiTabs', () => {
+  return {
+    Tabs: ({ value, onChange, children }) => (
+      <button
+        value={value}
+        onClick={event => onChange(event, 'data')}
+        data-testid="tabs"
+      >
+        {children}
+      </button>
+    ),
+    Tab: ({ value, label, href, id, 'aria-controls': ariaControls }) => (
+      <div
+        data-testid="tab"
+        value={value}
+        label={label}
+        href={href}
+        id={id}
+        aria-controls={ariaControls}
+      ></div>
+    )
+  }
+})
+
+jest.mock('./AppList', () => {
+  // eslint-disable-next-line react/display-name
+  return () => <div data-testid="AppList"></div>
+})
+
+jest.mock('./DataList', () => {
+  // eslint-disable-next-line react/display-name
+  return () => <div data-testid="DataList"></div>
+})
+
+describe('PermissionsTab', () => {
+  it('should match snapshot', () => {
+    const { container } = render(<PermissionsTab />)
+    expect(container).toMatchSnapshot()
+  })
+  it('should display AppList when Application Tab is selected', () => {
+    const { getByTestId } = render(<PermissionsTab />)
+    expect(getByTestId('AppList')).toBeTruthy()
+  })
+
+  it('should display DataList when Data Tab is selected', () => {
+    const { getByTestId } = render(<PermissionsTab />)
+    const tabs = getByTestId('tabs')
+    fireEvent.click(tabs, { event: 'event' })
+    expect(getByTestId('DataList')).toBeTruthy()
+  })
+})

--- a/src/components/Permissions/__snapshots__/AppList.spec.jsx.snap
+++ b/src/components/Permissions/__snapshots__/AppList.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Permissions should display appName when query has been loaded 1`] = `
+exports[`AppList should display appName when query has been loaded 1`] = `
 <div>
   <div
     data-narrow="true"
@@ -9,7 +9,7 @@ exports[`Permissions should display appName when query has been loaded 1`] = `
     <div
       data-testid="page-title"
     >
-      Permissions.title
+      Applications
     </div>
     <ul
       class="MuiList-root MuiList-padding"
@@ -33,7 +33,7 @@ exports[`Permissions should display appName when query has been loaded 1`] = `
             </div>
             <div
               data-primary="Alan"
-              data-secondary="Permissions.numberOfPermissions"
+              data-secondary="0 permissions"
               data-testid="ListItemText"
             />
             <span
@@ -64,7 +64,7 @@ exports[`Permissions should display appName when query has been loaded 1`] = `
             </div>
             <div
               data-primary="Contacts"
-              data-secondary="Permissions.numberOfPermissions 3"
+              data-secondary="3 permissions"
               data-testid="ListItemText"
             />
             <span
@@ -81,7 +81,7 @@ exports[`Permissions should display appName when query has been loaded 1`] = `
 </div>
 `;
 
-exports[`Permissions should display sorted app and konnector names when query is not loading 1`] = `
+exports[`AppList should display sorted app and konnector names when query is not loading 1`] = `
 <div>
   <div
     data-narrow="true"
@@ -90,7 +90,7 @@ exports[`Permissions should display sorted app and konnector names when query is
     <div
       data-testid="page-title"
     >
-      Permissions.title
+      Applications
     </div>
     <ul
       class="MuiList-root MuiList-padding"
@@ -114,7 +114,7 @@ exports[`Permissions should display sorted app and konnector names when query is
             </div>
             <div
               data-primary="Alan"
-              data-secondary="Permissions.numberOfPermissions"
+              data-secondary="0 permissions"
               data-testid="ListItemText"
             />
             <span
@@ -145,7 +145,7 @@ exports[`Permissions should display sorted app and konnector names when query is
             </div>
             <div
               data-primary="Contacts"
-              data-secondary="Permissions.numberOfPermissions 3"
+              data-secondary="3 permissions"
               data-testid="ListItemText"
             />
             <span

--- a/src/components/Permissions/__snapshots__/DataList.spec.jsx.snap
+++ b/src/components/Permissions/__snapshots__/DataList.spec.jsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataList should display DataList title 1`] = `
+<div>
+  <div
+    data-narrow="true"
+    data-testid="page"
+  >
+    <div
+      data-testid="page-title"
+    >
+      Data
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Permissions/__snapshots__/PermissionsTab.spec.jsx.snap
+++ b/src/components/Permissions/__snapshots__/PermissionsTab.spec.jsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PermissionsTab should match snapshot 1`] = `
+<div>
+  <div
+    class="u-mv-2 u-mh-2 u-pb-3 Page--narrow"
+  >
+    <button
+      data-testid="tabs"
+      value="slug"
+    >
+      <div
+        aria-controls="simple-tabpanel-0"
+        data-testid="tab"
+        href="#/permissions/slug"
+        id="simple-tab-0"
+        label="Permissions.applications"
+        value="slug"
+      />
+      <div
+        aria-controls="simple-tabpanel-1"
+        data-testid="tab"
+        href="#/permissions/data"
+        id="simple-tab-1"
+        label="Permissions.data"
+        value="data"
+      />
+    </button>
+    <hr
+      class="MuiDivider-root u-mb-1"
+    />
+    <div
+      aria-labelledby="simple-tab-slug"
+      id="simple-tabpanel-slug"
+      role="tabpanel"
+    >
+      <div
+        data-testid="AppList"
+      />
+    </div>
+    <div
+      aria-labelledby="simple-tab-data"
+      hidden=""
+      id="simple-tabpanel-data"
+      role="tabpanel"
+    />
+  </div>
+</div>
+`;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,8 +13,9 @@ import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
 import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 import PhoneIcon from 'cozy-ui/transpiled/react/Icons/Phone'
 import ArchiveIcon from 'cozy-ui/transpiled/react/Icons/Archive'
-import { useI18n } from 'cozy-ui/transpiled/react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import flag from 'cozy-flags'
+import { routes } from 'constants/routes'
 
 export const Sidebar = () => {
   const { t } = useI18n()
@@ -65,7 +66,7 @@ export const Sidebar = () => {
         {flag('settings.permissions-dashboard') && (
           <NavItem>
             <RouterLink
-              to="/permissions"
+              to={routes.appList}
               className={NavLink.className}
               activeClassName={NavLink.activeClassName}
             >

--- a/src/components/Sidebar.spec.jsx
+++ b/src/components/Sidebar.spec.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Sidebar from './Sidebar'
 import flag from 'cozy-flags'
 
-jest.mock('cozy-ui/transpiled/react', () => ({
+jest.mock('cozy-ui/transpiled/react/I18n', () => ({
   useI18n: () => ({ t: name => name })
 }))
 jest.mock('react-router-dom', () => ({

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,4 @@
+export const routes = {
+  appList: '/permissions/slug',
+  dataList: '/permissions/data'
+}

--- a/src/containers/Permission.jsx
+++ b/src/containers/Permission.jsx
@@ -9,13 +9,14 @@ import CozyClient, {
   isQueryLoading,
   hasQueryBeenLoaded
 } from 'cozy-client'
-import { useI18n } from 'cozy-ui/transpiled/react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Page from 'components/Page'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { displayPermissions } from './helpers/permissionsHelper'
 import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import { routes } from 'constants/routes'
 
 const Permission = ({ match }) => {
   const { t } = useI18n()
@@ -73,20 +74,19 @@ const Permission = ({ match }) => {
           {t('Permissions.failedRequest')}
         </Typography>
       ) : (
-        <div>
+        <React.Fragment>
           <IconButton
             className="u-mr-half"
-            href={`#/permissions/${appName.toLowerCase()}`}
+            href={`#${routes.appList}/${appName.toLowerCase()}`}
           >
             <Icon icon={PreviousIcon} size={16} />
           </IconButton>
-
           <Typography variant="h1">
             Application: {appName.toUpperCase()}
           </Typography>
           <Typography variant="h2">Permission: {permissionName}</Typography>
           <Typography variant="h3">{t(displayPermissions(verbs))}</Typography>
-        </div>
+        </React.Fragment>
       )}
     </Page>
   )

--- a/src/containers/Permission.spec.jsx
+++ b/src/containers/Permission.spec.jsx
@@ -2,10 +2,7 @@ import { render } from '@testing-library/react'
 import React from 'react'
 import Permission from './Permission'
 import { Q, useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
-
-jest.mock('cozy-ui/transpiled/react', () => {
-  return { useI18n: () => ({ t: x => x }) }
-})
+import AppLike from 'test/AppLike'
 
 jest.mock('react-router-dom', () => {
   return {
@@ -106,14 +103,22 @@ describe('Permission', () => {
 
   it('should display appName when query has been loaded', () => {
     hasQueryBeenLoaded.mockReturnValue(true)
-    const { container } = render(<Permission />)
+    const { container } = render(
+      <AppLike>
+        <Permission />
+      </AppLike>
+    )
     expect(container).toMatchSnapshot()
   })
 
   it('should render a spinner when query is loading and has not been loaded', () => {
     isQueryLoading.mockReturnValue(true)
     hasQueryBeenLoaded.mockReturnValue(false)
-    const { queryByTestId } = render(<Permission />)
+    const { queryByTestId } = render(
+      <AppLike>
+        <Permission />
+      </AppLike>
+    )
     expect(queryByTestId('Spinner')).toBeTruthy()
   })
 })

--- a/src/containers/PermissionsApplication.jsx
+++ b/src/containers/PermissionsApplication.jsx
@@ -22,6 +22,7 @@ import ListItemIcon, {
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import { routes } from 'constants/routes'
 
 import CozyClient, {
   Q,
@@ -116,7 +117,7 @@ const PermissionsApplication = ({ match, t }) => {
                   return (
                     <div key={name}>
                       <Link
-                        to={`/permissions/${appName}/${name}`}
+                        to={`${routes.appList}/${appName}/${name}`}
                         key={name}
                         style={{ textDecoration: 'none' }}
                       >

--- a/src/containers/__snapshots__/Permission.spec.jsx.snap
+++ b/src/containers/__snapshots__/Permission.spec.jsx.snap
@@ -6,50 +6,48 @@ exports[`Permission should display appName when query has been loaded 1`] = `
     data-narrow="true"
     data-testid="page"
   >
-    <div>
-      <a
-        aria-disabled="false"
-        class="MuiButtonBase-root MuiIconButton-root u-mr-half large"
-        href="#/permissions/drive"
-        tabindex="0"
+    <a
+      aria-disabled="false"
+      class="MuiButtonBase-root MuiIconButton-root u-mr-half large"
+      href="#/permissions/slug/drive"
+      tabindex="0"
+    >
+      <span
+        class="MuiIconButton-label"
       >
-        <span
-          class="MuiIconButton-label"
+        <svg
+          class="styles__icon___23x3R"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
         >
-          <svg
-            class="styles__icon___23x3R"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <path
-              d="M3.414 7h11.58C15.548 7 16 7.444 16 8c0 .552-.45 1-1.007 1H3.414l5.293 5.293a1 1 0 01-1.414 1.414l-7-7a1 1 0 010-1.414l7-7a1 1 0 111.414 1.414L3.414 7z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </a>
-      <h1
-        class="MuiTypography-root MuiTypography-h1 MuiTypography-colorTextPrimary"
-      >
-        Application: 
-        DRIVE
-      </h1>
-      <h2
-        class="MuiTypography-root MuiTypography-h2 MuiTypography-colorTextPrimary"
-      >
-        Permission: 
-        apps
-      </h2>
-      <h3
-        class="MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary"
-      >
-        Permissions.write
-      </h3>
-    </div>
+          <path
+            d="M3.414 7h11.58C15.548 7 16 7.444 16 8c0 .552-.45 1-1.007 1H3.414l5.293 5.293a1 1 0 01-1.414 1.414l-7-7a1 1 0 010-1.414l7-7a1 1 0 111.414 1.414L3.414 7z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </a>
+    <h1
+      class="MuiTypography-root MuiTypography-h1 MuiTypography-colorTextPrimary"
+    >
+      Application: 
+      DRIVE
+    </h1>
+    <h2
+      class="MuiTypography-root MuiTypography-h2 MuiTypography-colorTextPrimary"
+    >
+      Permission: 
+      apps
+    </h2>
+    <h3
+      class="MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary"
+    >
+      Write
+    </h3>
   </div>
 </div>
 `;

--- a/src/lib/withAllLocales.spec.js
+++ b/src/lib/withAllLocales.spec.js
@@ -1,7 +1,7 @@
 import withAllLocales from './withAllLocales'
 import React from 'react'
 import { render } from '@testing-library/react'
-import { useI18n } from 'cozy-ui/transpiled/react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 describe('withAllLocales', () => {
   it('should provide translations from CozyClient and CozySettings', () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -397,6 +397,8 @@
     "read": "Read",
     "readAndWrite": "Read and Write",
     "write": "Write",
-    "numberOfPermissions": "%{smart_count} permission |||| %{smart_count} permissions"
+    "numberOfPermissions" : "%{smart_count} permission |||| %{smart_count} permissions",
+    "applications": "Applications",
+    "data": "Data"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -402,6 +402,8 @@
     "read": "Lecture",
     "readAndWrite": "Lecture et Écriture",
     "write": "Écriture",
-    "numberOfPermissions" : "%{smart_count} permission |||| %{smart_count} permissions"
+    "numberOfPermissions" : "%{smart_count} permission |||| %{smart_count} permissions",
+    "applications": "Applications",
+    "data": "Données"
   }
 }

--- a/src/test/AppLike.jsx
+++ b/src/test/AppLike.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import I18n from 'cozy-ui/transpiled/react/I18n'
+import langEn from '../locales/en.json'
+
+export const TestI18n = ({ children }) => {
+  return (
+    <I18n lang={'en'} dictRequire={() => langEn}>
+      {children}
+    </I18n>
+  )
+}
+
+const AppLike = ({ children }) => <TestI18n>{children}</TestI18n>
+
+export default AppLike

--- a/test/__snapshots__/app.spec.js.snap
+++ b/test/__snapshots__/app.spec.js.snap
@@ -47,16 +47,16 @@ exports[`App component only should be mounted correctly 1`] = `
       <Route
         component={[Function]}
         exact={true}
-        path="/permissions"
+        path="/permissions/:page"
       />
       <Route
         component={[Function]}
         exact={true}
-        path="/permissions/:app"
+        path="/permissions/slug/:app"
       />
       <Route
         component={[Function]}
-        path="/permissions/:app/:permission"
+        path="/permissions/slug/:app/:permission"
       />
       <Route
         component={[Function]}
@@ -67,6 +67,12 @@ exports[`App component only should be mounted correctly 1`] = `
         from="/"
         push={false}
         to="/profile"
+      />
+      <Redirect
+        exact={true}
+        from="/permissions"
+        push={false}
+        to="/permissions/slug"
       />
       <Redirect
         from="*"


### PR DESCRIPTION
The list of applications is now on the path '#/permissions/slug',
The data page is on the path '#/permissions/data'

<img width="807" alt="Capture d’écran 2022-08-09 à 12 23 58" src="https://user-images.githubusercontent.com/57950292/183625919-66b8b382-2525-4f16-ae1c-ef98ecf3bc93.png">
