### PR TITLE
feat: Enable TypeScript support on the application

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,8 @@
     "react": {
       "version": "detect"
     }
+  },
+  "parserOptions": {
+    "project": "tsconfig.json"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironmentOptions: {
      url: 'http://localhost/'
   },
-  moduleFileExtensions: ['js', 'jsx', 'json', 'styl'],
+  moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx', 'styl'],
   setupFilesAfterEnv: ['<rootDir>/test/jestLib/setup.js'],
   moduleDirectories: ['<rootDir>/src', 'node_modules'],
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "tx": "tx pull --all || true",
     "lint": "yarn lint:js",
-    "lint:js": "eslint '{src,test}/**/*.{js,jsx}'",
+    "lint:js": "eslint '{src,test}/**/*.{js,jsx,ts,tsx}'",
     "build": "yarn build:browser",
     "build:browser": "cozy-scripts build --browser",
     "build:mobile": "cozy-scripts build --mobile",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "es5",
+    "strict": true
+  }
+}


### PR DESCRIPTION
Nothing is required after pulling this commit.
You can continue coding in js/jsx or start using TypeScript.
Be warned that TypeScript is in strict mode,
AND even stricter with ESLint.

ESlint errors will fail the CI. TS errors though will not fail the CI.

I would still advise you to not let any TS error subsist,
else TS doesn't make really sense.