### PR TITLE
fix: Improve new menu after staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-keys-lib": "^3.11.1",
     "cozy-realtime": "3.13.1",
     "cozy-sharing": "3.10.0",
-    "cozy-ui": "^70.6.2",
+    "cozy-ui": "74.0.0",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.8.1",
     "react": "18.2.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -30,19 +30,21 @@ initFlags()
 
 export class App extends Component {
   render() {
-    const { isMobile } = this.props
+    const { isMobile, isTablet } = this.props
+    const isSmallView = isMobile || isTablet
+    const isBigView = !isSmallView
 
     return (
       <Layout>
         {App.renderExtra()}
         <FlagSwitcher />
         <Alerter />
-        {!isMobile && <Sidebar />}
+        {isBigView && <Sidebar />}
         <RealTimeQueries doctype="io.cozy.oauth.clients" />
 
         <Main>
           <Routes>
-            {isMobile && <Route path="/menu" element={<Menu />} />}
+            {isSmallView && <Route path="/menu" element={<Menu />} />}
             <Route path="/redirect" element={<IntentRedirect />} />
             <Route path="/profile/*" element={<Profile />} />
             <Route path="/profile/password" element={<Passphrase />} />
@@ -68,7 +70,7 @@ export class App extends Component {
             <Route
               path="*"
               element={
-                <Navigate to={isMobile ? '/menu' : '/profile'} replace />
+                <Navigate to={isSmallView ? '/menu' : '/profile'} replace />
               }
             />
           </Routes>
@@ -87,9 +89,9 @@ const mapStateToProps = state => ({
 })
 
 const AppWithBreakpoints = props => {
-  const { isMobile } = useBreakpoints()
+  const { isMobile, isTablet } = useBreakpoints()
 
-  return <App {...props} isMobile={isMobile} />
+  return <App {...props} isMobile={isMobile} isTablet={isTablet} />
 }
 
 export default hot(module)(

--- a/src/components/CozyTreeView.jsx
+++ b/src/components/CozyTreeView.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
-import mergeClasses from '@material-ui/styles/mergeClasses'
-
-import Collapse from 'cozy-ui/transpiled/react/Collapse'
 import MuiTreeItem from '@material-ui/lab/TreeItem'
 import MuiTreeView from '@material-ui/lab/TreeView'
+import React from 'react'
+import mergeClasses from '@material-ui/styles/mergeClasses'
+import { makeStyles } from '@material-ui/core/styles'
+
 import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+import Collapse from 'cozy-ui/transpiled/react/Collapse'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 
 const useItemClasses = divider =>

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -20,10 +20,10 @@ const PageTitle = ({ children, ...rest }) => {
   const isRoot = useMatch('/menu')
   const navigate = useNavigate()
   const navigateBack = () => navigate('..')
-  const { isMobile } = useBreakpoints()
+  const { isMobile, isTablet } = useBreakpoints()
   const { t } = useI18n()
 
-  return isMobile ? (
+  return isMobile || isTablet ? (
     <>
       {!isRoot && (
         <BarLeft>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,11 +19,13 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import { routes } from 'constants/routes'
 import { useDiskPercentage } from 'hooks/useDiskPercentage'
 import { useLogout } from 'hooks/useLogout'
+import { useOffersLink } from 'hooks/useOffersLink'
 
 export const Sidebar = (): JSX.Element => {
   const { t } = useI18n()
   const percent = useDiskPercentage()
   const logout = useLogout()
+  const offersLink = useOffersLink()
 
   return (
     <nav role="navigation">
@@ -45,6 +47,15 @@ export const Sidebar = (): JSX.Element => {
             primary={t('Nav.profile')}
             icon={PeopleIcon}
           />
+
+          {flag('settings.enable_premium_links') && offersLink && (
+            <MenuItemAnchor
+              primary={t('Nav.primary_plan')}
+              href={offersLink}
+              target="_blank"
+              icon={UnknowIcon}
+            />
+          )}
 
           <MenuItemNavLink
             to={routes.connectedDevices}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export const Sidebar = (): JSX.Element => {
   const offersLink = useOffersLink()
 
   return (
-    <nav role="navigation">
+    <nav role="navigation" style={{ minWidth: '362px' }}>
       <List>
         {isFlagshipApp() ||
           (flag('settings.flagship-mode') && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
+import CozyCircle from 'cozy-ui/transpiled/react/Icons/CozyCircle'
 import DevicesIcon from 'cozy-ui/transpiled/react/Icons/Devices'
 import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
 import GraphCircle from 'cozy-ui/transpiled/react/Icons/GraphCircle'
 import HandIcon from 'cozy-ui/transpiled/react/Icons/Hand'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import LockScreen from 'cozy-ui/transpiled/react/Icons/LockScreen'
 import Logout from 'cozy-ui/transpiled/react/Icons/Logout'
 import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 import UnknowIcon from 'cozy-ui/transpiled/react/Icons/Unknow'
@@ -36,7 +38,7 @@ export const Sidebar = (): JSX.Element => {
               <MenuItemNavLink
                 to={routes.lockScreen}
                 primary={t('Nav.primary_lock_screen')}
-                icon={PeopleIcon} // @todo icon
+                icon={LockScreen}
               />
             </MenuList>
           ))}
@@ -53,7 +55,7 @@ export const Sidebar = (): JSX.Element => {
               primary={t('Nav.primary_plan')}
               href={offersLink}
               target="_blank"
-              icon={UnknowIcon}
+              icon={CozyCircle}
             />
           )}
 

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -2,6 +2,7 @@ import React, { ReactChild, ReactNode } from 'react'
 
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import styles from 'components/menu/menu.styl'
 
 type MenuListProps = {
   title: string
@@ -10,13 +11,13 @@ type MenuListProps = {
 
 export const MenuList = ({ title, children }: MenuListProps): JSX.Element => (
   <>
-    <ListSubheader>{title}</ListSubheader>
+    <ListSubheader className={styles['subheader']}>{title}</ListSubheader>
 
     {Array.isArray(children)
       ? children.map((child, index, array) => (
           <React.Fragment key={index}>
             {child}
-            {!(index === array.length - 1) && (
+            {!(index === array.length - 1) && child && (
               <Divider component="li" variant="inset" />
             )}
           </React.Fragment>

--- a/src/components/menu/menu.styl
+++ b/src/components/menu/menu.styl
@@ -1,0 +1,8 @@
+@require 'cozy-ui'
+
+:local
+  .subheader
+      margin-bottom spacing_values.m
+
+  .subheader:not(:first-child)
+      margin-top spacing_values.m

--- a/src/hooks/useOffersLink.ts
+++ b/src/hooks/useOffersLink.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { useClient, Q } from 'cozy-client'
+import logger from 'lib/logger'
+
+const warn = (logger as { warn: (...args: unknown[]) => void }).warn
+
+type QueryResult<T> = { data: { attributes: T } }
+type ExpectedContext = QueryResult<{
+  manager_url?: string
+  enable_premium_links?: string
+}>
+type ExpectedInstance = QueryResult<{ uuid?: string }>
+
+export const useOffersLink = (): undefined | string | null => {
+  const client = useClient()
+  const [offersLink, setOffersLink] = useState<undefined | string | null>()
+
+  useEffect(() => {
+    const asyncCore = async (): Promise<void> => {
+      try {
+        const { data: context } = (await client.query(
+          Q('io.cozy.settings').getById('context')
+        )) as ExpectedContext
+
+        const { data: instance } = (await client.query(
+          Q('io.cozy.settings').getById('instance')
+        )) as ExpectedInstance
+
+        const { manager_url, enable_premium_links } = context.attributes
+        const { uuid } = instance.attributes
+
+        setOffersLink(
+          enable_premium_links && manager_url && uuid
+            ? `${manager_url}/cozy/instances/${uuid}/premium`
+            : null
+        )
+      } catch (error) {
+        warn('Error while fetching offers link', error)
+      }
+    }
+
+    offersLink === undefined && client && asyncCore()
+  }, [client, offersLink])
+
+  return offersLink
+}

--- a/src/lib/makeDiskInfos.spec.ts
+++ b/src/lib/makeDiskInfos.spec.ts
@@ -9,12 +9,12 @@ it('computes disk percent with a quota', () => {
   expect(makeDiskInfos('115600793', '5000000000')).toStrictEqual({
     humanDiskQuota: '4.66',
     humanDiskUsage: '0.11',
-    percentUsage: '2.31'
+    percentUsage: '2'
   })
   expect(makeDiskInfos('22115600793', '90000000000')).toStrictEqual({
     humanDiskQuota: '83.82',
     humanDiskUsage: '20.60',
-    percentUsage: '24.57'
+    percentUsage: '25'
   })
   expect(makeDiskInfos('5000000000', '5000000000')).toStrictEqual({
     humanDiskQuota: '4.66',
@@ -24,7 +24,7 @@ it('computes disk percent with a quota', () => {
   expect(makeDiskInfos('75000000000', '107374182400')).toStrictEqual({
     humanDiskQuota: '100',
     humanDiskUsage: '69.85',
-    percentUsage: '69.85'
+    percentUsage: '70'
   })
 })
 
@@ -32,7 +32,7 @@ it('computes disk percent without a quota', () => {
   expect(makeDiskInfos('1156007930', '')).toStrictEqual({
     humanDiskQuota: '100',
     humanDiskUsage: '1.08',
-    percentUsage: '1.08'
+    percentUsage: '1'
   })
   expect(makeDiskInfos('0', undefined)).toStrictEqual({
     humanDiskQuota: '100',

--- a/src/lib/makeDiskInfos.ts
+++ b/src/lib/makeDiskInfos.ts
@@ -24,10 +24,10 @@ const makeDiskInfos = (
 ): DiskInfos =>
   Object.fromEntries(
     Object.entries(computeDiskInfos(+usage, quota ? +quota : undefined)).map(
-      ([key, value]) => [
-        [key.replace('disk', 'humanDisk')],
-        formatDecimals(value)
-      ]
+      ([key, value]) =>
+        key === 'percentUsage'
+          ? [key, Math.round(value).toString()]
+          : [[key.replace('disk', 'humanDisk')], formatDecimals(value)]
     )
   ) as DiskInfos
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,7 @@
     "primary_save_journeys": "Mémoriser mes trajets",
     "primary_support": "Support",
     "primary_wifi_sync": "Synchroniser seulement en wifi",
+    "primary_plan": "Forfait",
     "profile": "Profile",
     "secondary_free": "Gratuit",
     "secondary_used": "utilisé",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -81,6 +81,7 @@
     "primary_save_journeys": "Mémoriser mes trajets",
     "primary_support": "Support",
     "primary_wifi_sync": "Synchroniser seulement en wifi",
+    "primary_plan": "Forfait",
     "profile": "Profil",
     "secondary_free": "Gratuit",
     "secondary_used": "%{percent}% utilisé",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,10 +5770,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^70.6.2:
-  version "70.6.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-70.6.2.tgz#e13182d28d97f7e762fa3f761eec213565c2c833"
-  integrity sha512-NbPIicACol5LF9dcNsmEiu15pTGIev1jE5StaiosUwYp5yG/fZfMDoOm07TmNtv8PnL+Xak2/d8dPox6tipj7g==
+cozy-ui@74.0.0:
+  version "74.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-74.0.0.tgz#13820a96ae7a4f681fda02015eabcb78c99b1fc6"
+  integrity sha512-76sxYqqeCdUO4cBFFob29YUADwsPTl7DsnmZLYFZ2DcVVfxh4Nl3GiwmWlLivbrCDSgGq8DVlep3rr2fIMKheg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -11409,9 +11409,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.8":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.8":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#8535a9da5c334890dcf95ae4e6aeb4f6ec2d56a0"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#8535a9da5c334890dcf95ae4e6aeb4f6ec2d56a0"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
## Feature

This handles many small UI fixes needed after staging review. See the [ticket](https://trello.com/c/J1yWZ7pS/573-%E2%9A%99%EF%B8%8F-set-menu-en-premi%C3%A8re-page-dans-lapplication-settings-4j) for more informations.

## Context

This is in the broad context of biometrics features to be added to the Flagship App. Perfecting the UI on the web is still part of what we have to do.

## Implementation

CSS adjusting, new hook for getting manager link, updated hook to round disk usage percentage, new icons, nothing big.

## Testing

No tests were added, it didn't seem useful as most of the features are in Typescript. Existing tests were updated though.

## Screenshots

![image](https://user-images.githubusercontent.com/12577784/187918167-665a5fe1-ddc5-4e7e-9014-07efe2cff0c2.png) 
![image](https://user-images.githubusercontent.com/12577784/187918249-489062d5-cba7-4a80-915a-8cbad9bb389f.png)

## Thoughts

Might be still useful to add tests down the road to all new hooks even if they're fully typed.
