### PR TITLE
fix: Update Permission Tab

### DIFF
--- a/src/components/Permissions/PermissionsTab.jsx
+++ b/src/components/Permissions/PermissionsTab.jsx
@@ -4,7 +4,6 @@ import Tabs from 'cozy-ui/transpiled/react/Tabs'
 import Tab from 'cozy-ui/transpiled/react/Tab'
 import AppList from './AppList'
 import DataList from './DataList'
-import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider/index'
 import { routes } from 'constants/routes'
 import { useParams, useNavigate } from 'react-router-dom'
 import withAllLocales from '../../lib/withAllLocales'
@@ -41,7 +40,12 @@ const PermissionsTab = ({ t }) => {
   return (
     <BreakpointsProvider>
       <Page narrow>
-        <Tabs value={page} onChange={handleChange} segmented>
+        <Tabs
+          value={page}
+          onChange={handleChange}
+          segmented
+          style={{ width: '20rem' }}
+        >
           <Tab
             value="slug"
             label={t('Permissions.applications')}
@@ -55,7 +59,6 @@ const PermissionsTab = ({ t }) => {
             {...a11yProps(1)}
           />
         </Tabs>
-        <Divider className="u-mb-1" />
         <TabPanel value={page} index="slug">
           <AppList />
         </TabPanel>

--- a/src/components/Permissions/__snapshots__/PermissionsTab.spec.jsx.snap
+++ b/src/components/Permissions/__snapshots__/PermissionsTab.spec.jsx.snap
@@ -26,9 +26,6 @@ exports[`PermissionsTab should match snapshot 1`] = `
         value="data"
       />
     </button>
-    <hr
-      class="MuiDivider-root u-mb-1"
-    />
     <div
       aria-labelledby="simple-tab-slug"
       id="simple-tabpanel-slug"


### PR DESCRIPTION
- delete divider
- shorten the tab

from this :
<img width="575" alt="Capture d’écran 2022-09-07 à 09 40 46" src="https://user-images.githubusercontent.com/57950292/188907325-f9d79767-8cbf-47ac-8d55-f3d768ff4783.png">

to that : 
<img width="575" alt="Capture d’écran 2022-09-07 à 09 40 37" src="https://user-images.githubusercontent.com/57950292/188907412-2bde34e5-20b0-400c-8e37-b3935f6315a9.png">
