### PR TITLE
fix: Use only one way to inject data

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -22,15 +22,6 @@
 </head>
 <div
   role="application"
-  data-cozy-token="{{.Token}}"
-  data-cozy-domain="{{.Domain}}"
-  data-cozy-locale="{{.Locale}}"
-  data-cozy-app-name="{{.AppName}}"
-  data-cozy-app-name-prefix="{{.AppNamePrefix}}"
-  data-cozy-app-slug="{{.AppSlug}}"
-  data-cozy-tracking="{{.Tracking}}"
-  data-cozy-app-editor="{{.AppEditor}}"
-  data-cozy-icon-path="{{.IconPath}}"
   data-cozy="{{.CozyData}}"
 >
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>


### PR DESCRIPTION
This is the recommended way in order to get all the new added attributes without editing the ejs. 