### PR TITLE
fix: Remove vertical scrolling on mobile menu

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import classNames from 'classnames'
 import { Route, Navigate, Routes } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { hot } from 'react-hot-loader'
@@ -21,6 +22,7 @@ import Profile from 'containers/Profile'
 import Sessions from 'containers/Sessions'
 import Sidebar from 'components/Sidebar'
 import Storage from 'containers/Storage'
+import styles from 'styles/index.styl'
 import { LockScreen } from 'components/pages/LockScreen'
 import { Menu } from 'components/pages/Menu'
 import { initFlags } from 'lib/flags'
@@ -35,7 +37,9 @@ export class App extends Component {
     const isBigView = !isSmallView
 
     return (
-      <Layout>
+      <Layout
+        className={classNames({ [styles['Layout--small-view']]: isSmallView })}
+      >
         {App.renderExtra()}
         <FlagSwitcher />
         <Alerter />

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -4,3 +4,7 @@
     .set-markdown-link
         color var(--dodgerBlue)
         text-decoration none
+
+.Layout--small-view
+    &::after
+        content none


### PR DESCRIPTION
### Bug

Related to https://trello.com/c/FhQCY4DE/590-scroll-inutile-dans-le-menu-de-settings

When on the Menu page on mobile, there is an unwanted and apparently useless Y scrolling ability. It makes the UI look semi-broken.

### Fix

Overwriting the `:after` pseudo-element in `Layout` when on a small screen because this page is a special case and doesn't have anything to show on the bottom of the page (like a bottom sidebar which we do not have anymore on `cozy-settings`). So we just remove that pseudo-element which was creating unwanted scrolling.

### Testing

Manual testing in the browser

### Thoughts

At this point, I didn't think updating `cozy-ui` was necessary because it is a special app scenario
