### PR TITLE
wip: Fix bug reload app permissions -DO NOT MERGE

### DIFF
--- a/src/components/Permissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions.jsx
@@ -57,6 +57,17 @@ const PermissionsApplication = ({ t }) => {
   const { slug: slugName } = useParams()
   const THIRTY_SECONDS = 30 * 1000
 
+  // We don't care about this data, but it makes the reload work
+  const queryResultAppsLikeAppList = useQuery(Q(APPS_DOCTYPE), {
+    as: APPS_DOCTYPE,
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS)
+  })
+
+  const queryResultKonnectorsLikeAppList = useQuery(Q(KONNECTORS_DOCTYPE), {
+    as: KONNECTORS_DOCTYPE,
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(THIRTY_SECONDS)
+  })
+
   const queryResultApps = useQuery(
     Q(APPS_DOCTYPE).getById('io.cozy.apps/' + slugName),
     {


### PR DESCRIPTION
Adding queryResultLikeAppList makes it work.
The data we need is in permissions. When we reload the page, permissions is nested inside attributes. We don't want to access this data with attributes.
Cozy-Stack replies the same thing every time so the only difference could be in Cozy-Client