### PR TITLE
feat: Update cozy client

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@material-ui/lab": "4.0.0-alpha.61",
     "classnames": "2.3.1",
-    "cozy-client": "^32.8.0",
+    "cozy-client": "^33.0.8",
     "cozy-device-helper": "2.4.0",
     "cozy-doctypes": "1.83.7",
     "cozy-flags": "^2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,16 +5464,16 @@ cozy-client@^27.14.4:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^32.8.0:
-  version "32.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.8.0.tgz#a6ac28ff9403547a867f204bfa2c186a52bbfbfc"
-  integrity sha512-h79OF38QdSlhaSz1sQZh2ZdPO2pBT+N5w4r8vCyJfbLjVpBNMNtBItdvJsOQewHbcaC4bpc+1nM6NMaQONmELQ==
+cozy-client@^33.0.8:
+  version "33.0.8"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.0.8.tgz#0ce21f3e3a942b0905a554ff4d39318e4c2ad712"
+  integrity sha512-UeLPVG8fnGKVOyS+WSYNbW4OSFgKxlLoI06DJ4t4a/ez0iteoQyVQQ986kqHp1CPKdu+ps7uSRuoMxZCIohJPA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^32.7.3"
+    cozy-stack-client "^33.0.8"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5735,10 +5735,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^32.7.3:
-  version "32.7.3"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-32.7.3.tgz#f2b46e8e31d17bb27467d189e5956f004d2fbcdf"
-  integrity sha512-TakiZnPIZ4idQmTfyyDc2MkEEVcfOAPbQNj7/BhtYFX+2p1ocNfHA0EAWF2fd/ijfcxOgj3i5lxRjDbilxy9PQ==
+cozy-stack-client@^33.0.8:
+  version "33.0.8"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.0.8.tgz#e08c432687f3b9c5d3c3269634d0316c873e92cb"
+  integrity sha512-Un149jVmuL9e7Y+N1u5pY75VOjo2MUL1nad5R3LRo/EwY4HkvcQ6hQBpYyN1ZnLJxTRI8lwNMXRfZiu9jCKvoQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
`cozy-client` as been upgraded to to `33.0.8` to spread attributes in the response data also with get requests. See https://github.com/cozy/cozy-client/pull/1246