### PR TITLE
fix: Use correct data to init the cozy-bar

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -52,12 +52,12 @@ const EnhancedI18n = connect(state => {
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('[role=application]')
   const root = createRoot(container)
-  const data = container.dataset
+  const data = JSON.parse(root.dataset.cozy)
 
   const protocol = window.location.protocol
   cozyClient.login({
-    uri: `${protocol}//${data.cozyDomain}`,
-    token: data.cozyToken
+    uri: `${protocol}//${data.domain}`,
+    token: data.token
   })
 
   const store = createStore()
@@ -67,10 +67,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cozy.bar.init({
     cozyClient,
-    appName: data.cozyAppName,
-    appEditor: data.cozyAppEditor,
-    iconPath: data.cozyIconPath,
-    lang: data.cozyLocale
+    appName: data.app.name,
+    appEditor: data.app.editor,
+    iconPath: data.app.icon,
+    lang: data.locale
   })
 
   root.render(


### PR DESCRIPTION
Since c7bf132a1dc71e042e1b1d4612893280839738a1
we changed the way to store the data from the
cozy-stack.

Let's read the data from the right path.