### PR TITLE
refactor: No need to use CozyClient.fromDOM

### DIFF
--- a/src/actions/email.spec.js
+++ b/src/actions/email.spec.js
@@ -3,11 +3,6 @@ import { createMockClient } from 'cozy-client/dist/mock'
 import { sendMessageToSupport } from './email'
 import { cozyFetch } from './index'
 
-jest.mock('lib/client', () => {
-  const CozyClient = jest.requireActual('cozy-client').default
-  return new CozyClient({})
-})
-
 jest.mock('./index', () => {
   const actions = jest.requireActual('./index')
   return {
@@ -23,10 +18,10 @@ jest.mock('./domUtils', () => ({
 
 describe('send email', () => {
   const setup = () => {
-    const store = createStore()
     const client = createMockClient({
       uri: 'http://cozy.tools:8080'
     })
+    const store = createStore(client)
     jest.spyOn(store, 'dispatch')
     return { store, client }
   }

--- a/src/actions/passphrase.js
+++ b/src/actions/passphrase.js
@@ -1,6 +1,6 @@
 import { cozyFetch } from 'actions'
 import { WebVaultClient } from 'cozy-keys-lib'
-import client from 'lib/client'
+import { getStackDomain } from 'actions/domUtils'
 
 export const UPDATE_PASSPHRASE = 'UPDATE_PASSPHRASE'
 export const UPDATE_PASSPHRASE_SUCCESS = 'UPDATE_PASSPHRASE_SUCCESS'
@@ -22,7 +22,7 @@ export const UPDATE_HINT_SUCCESS = 'UPDATE_HINT_SUCCESS'
 export const UPDATE_HINT_FAILURE = 'UPDATE_HINT_FAILURE'
 
 const getInstanceURL = () => {
-  return client.getStackClient().uri
+  return getStackDomain()
 }
 
 const invalidPassphraseErrorAction = {

--- a/src/components/DeleteAccount/FormModal.spec.jsx
+++ b/src/components/DeleteAccount/FormModal.spec.jsx
@@ -18,11 +18,6 @@ jest.mock('actions/email', () => ({
   sendDeleteAccountReasonEmail: jest.fn()
 }))
 
-jest.mock('lib/client', () => {
-  const CozyClient = jest.requireActual('cozy-client').default
-  return new CozyClient({})
-})
-
 const TestI18n = ({ children }) => {
   return (
     <I18n lang="en" dictRequire={() => langEn}>

--- a/src/components/DeleteAccount/helpers.spec.js
+++ b/src/components/DeleteAccount/helpers.spec.js
@@ -1,11 +1,6 @@
 import { createMockClient } from 'cozy-client'
 import { submitPassword, containerForTesting } from './helpers'
 
-jest.mock('lib/client', () => {
-  const CozyClient = jest.requireActual('cozy-client').default
-  return new CozyClient({})
-})
-
 const client = createMockClient({})
 const primaryAction = jest.fn()
 const setError = jest.fn()

--- a/src/components/ProfileView.spec.jsx
+++ b/src/components/ProfileView.spec.jsx
@@ -7,11 +7,6 @@ import CozyClient from 'cozy-client'
 import AppLike from '../../test/AppLike'
 import { PasswordSection } from './ProfileView'
 
-jest.mock('lib/client', () => {
-  const CozyClient = jest.requireActual('cozy-client').default
-  return new CozyClient({})
-})
-
 describe('PasswordSection', () => {
   const setup = ({ can_auth_with_password }) => {
     const client = new CozyClient({})

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -1,8 +1,0 @@
-import CozyClient from 'cozy-client'
-
-const client = CozyClient.fromDOM({
-  schema: {},
-  store: false
-})
-
-export default client

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,25 +15,25 @@ import openDeviceRevokeModale from 'reducers/openDeviceRevokeModale'
 import sessions from 'reducers/sessions'
 import storageData from 'reducers/storageData'
 import ui from 'reducers/ui'
-import cozyClient from 'lib/client'
 
-const appReducer = combineReducers({
-  devices,
-  fields,
-  twoFactor,
-  exportData,
-  importData,
-  instance,
-  claudy,
-  service,
-  emailStatus,
-  openDeviceRevokeModale,
-  deviceToRevoke,
-  passphrase,
-  sessions,
-  storageData,
-  ui,
-  cozy: cozyClient.reducer()
-})
+const appReducer = client =>
+  combineReducers({
+    devices,
+    fields,
+    twoFactor,
+    exportData,
+    importData,
+    instance,
+    claudy,
+    service,
+    emailStatus,
+    openDeviceRevokeModale,
+    deviceToRevoke,
+    passphrase,
+    sessions,
+    storageData,
+    ui,
+    cozy: client.reducer()
+  })
 
 export default appReducer

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -8,7 +8,7 @@ import {
   applyMiddleware
 } from 'redux'
 
-const createStore = () => {
+const createStore = client => {
   // Enable Redux dev tools
   const composeEnhancers =
     (__DEVELOPMENT__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
@@ -16,7 +16,7 @@ const createStore = () => {
   const middlewares = [thunkMiddleware]
 
   const store = reduxCreateStore(
-    appReducer,
+    appReducer(client),
     composeEnhancers(applyMiddleware(...middlewares))
   )
 

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -7,7 +7,7 @@ import 'styles/index.styl'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider, connect } from 'react-redux'
-import { CozyProvider } from 'cozy-client'
+import CozyClient, { CozyProvider } from 'cozy-client'
 import flag from 'cozy-flags'
 import { RealtimePlugin } from 'cozy-realtime'
 
@@ -18,7 +18,6 @@ import PiwikHashRouter from 'lib/PiwikHashRouter'
 import { WebviewIntentProvider } from 'cozy-intent'
 
 import App from 'components/App'
-import cozyClient from 'lib/client'
 
 import {
   StylesProvider,
@@ -53,14 +52,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('[role=application]')
   const root = createRoot(container)
   const data = JSON.parse(container.dataset.cozy)
-
   const protocol = window.location.protocol
-  cozyClient.login({
+  const cozyClient = new CozyClient({
     uri: `${protocol}//${data.domain}`,
-    token: data.token
+    token: data.token,
+    store: false
   })
 
-  const store = createStore()
+  const store = createStore(cozyClient)
   cozyClient.setStore(store)
   cozyClient.registerPlugin(flag.plugin)
   cozyClient.registerPlugin(RealtimePlugin)

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 
-import { CozyProvider } from 'cozy-client'
+import CozyClient, { CozyProvider } from 'cozy-client'
 import flag from 'cozy-flags'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
@@ -13,7 +13,6 @@ import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 
 import IntentService from 'containers/IntentService'
-import cozyClient from 'lib/client'
 
 import {
   StylesProvider,
@@ -40,12 +39,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const root = createRoot(container)
   const data = JSON.parse(container.dataset.cozy)
   const protocol = window.location.protocol
-
-  const store = createStore()
-  cozyClient.login({
+  const cozyClient = new CozyClient({
     uri: `${protocol}//${data.domain}`,
-    token: data.token
+    token: data.token,
+    store: false
   })
+  const store = createStore(cozyClient)
+
   cozyClient.registerPlugin(flag.plugin)
 
   root.render(


### PR DESCRIPTION
Let's update this old code to follow new convention. Also fix a warning 'CozyClient is already logged'