### PR TITLE
fix: Change source url

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -3,7 +3,7 @@
   "name_prefix": "Cozy",
   "slug": "settings",
   "icon": "app-icon.svg",
-  "source": "https://github.com/cozy/cozy-settings.git@build",
+  "source": "https://github.com/cozy/cozy-settings",
   "editor": "Cozy",
   "developer": {
     "name": "Cozy",


### PR DESCRIPTION
`@build` is not a supported syntax by github,
the link was broken.

And since we don't push inside the build branch
anymore, let's only use the path to the repository