### PR TITLE
fix: use singleDocData

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@material-ui/lab": "4.0.0-alpha.61",
     "classnames": "2.3.1",
-    "cozy-client": "^33.1.2",
+    "cozy-client": "^33.2.1",
     "cozy-device-helper": "^2.5.0",
     "cozy-doctypes": "1.83.7",
     "cozy-flags": "^2.8.7",
@@ -62,6 +62,7 @@
     "cozy-keys-lib": "^3.11.1",
     "cozy-realtime": "3.13.1",
     "cozy-sharing": "3.10.0",
+    "cozy-stack-client": "^33.2.0",
     "cozy-ui": "^76.2.0",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.8.1",

--- a/src/hooks/useOffersLink.ts
+++ b/src/hooks/useOffersLink.ts
@@ -25,14 +25,16 @@ export const useOffersLink = (): undefined | string | null => {
             definition: Q('io.cozy.settings').getById('context'),
             options: {
               fetchPolicy: CozyClient.fetchPolicies.olderThan(3000 * 1000),
-              as: `io.cozy.settings/context`
+              as: `io.cozy.settings/context`,
+              singleDocData: true
             }
           })) as ExpectedContext,
           (await client.fetchQueryAndGetFromState({
             definition: Q('io.cozy.settings').getById('instance'),
             options: {
               fetchPolicy: CozyClient.fetchPolicies.olderThan(3000 * 1000),
-              as: `io.cozy.settings/instance`
+              as: `io.cozy.settings/instance`,
+              singleDocData: true
             }
           })) as ExpectedInstance
         ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,16 +5465,16 @@ cozy-client@^27.14.4:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^33.1.2:
-  version "33.1.2"
-  resolved "https://registry.npmjs.org/cozy-client/-/cozy-client-33.1.2.tgz"
-  integrity sha512-r1SCwyFr//m1oyoqqr+yQ/OrqB8LTGi9NEaXckTarjbSj+woUtFlL5deQXj670jLB0mRxZIakMMNhG1j2FrKiw==
+cozy-client@^33.2.1:
+  version "33.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.2.1.tgz#623adc794c6ea36dd63e3b5db37d215a891e554f"
+  integrity sha512-WafBvbqoCI1odVI1Sc9la7Tkz3Q573iCrcGNRgYGIMCoqOwJimFg0sNIhC8KeaBGFug6SYzRCbUZmlg+k+Jx1Q==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^33.1.2"
+    cozy-stack-client "^33.2.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5736,10 +5736,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^33.1.2:
-  version "33.1.2"
-  resolved "https://registry.npmjs.org/cozy-stack-client/-/cozy-stack-client-33.1.2.tgz"
-  integrity sha512-fekoPMDlLUMsp/JRFO4h5+reiF78Rgtz+3igVN+X8jtKyZLfcsxJLfUC2dg8dISK+l1WsjT6DzCaF5uElWStWQ==
+cozy-stack-client@^33.2.0:
+  version "33.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.2.0.tgz#97b80514d68da2b6392f74d280f9867165b7d606"
+  integrity sha512-50vTnZvjCEYGx5nN+2rLhf63JZICNq9bXKY0QUFmfuMBfOTdD4EGw+EVA0YGxQYaz3E3FLrmMuIw5TtLzCDgcA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -11186,7 +11186,6 @@ mini-css-extract-plugin@0.5.0:
 
 "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
-  uid "6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
   resolved "https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
   dependencies:
     microee "0.0.6"
@@ -11341,7 +11340,6 @@ msgpack5@^4.0.2:
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"


### PR DESCRIPTION
When refactored query() to fetchQueryAndGetFromState() we lose this option, we fixed the real issue in cozy-client https://github.com/cozy/cozy-client/commit/a840bf46e2d6b5f28572e3f1d9f9558765d8e085 but let's be explict, this is better