### PR TITLE
fix: Fixed several issues

### DIFF
--- a/src/components/Permissions/AppPermissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.jsx
@@ -29,7 +29,7 @@ import {
 } from '../helpers/permissionsHelper'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 
-const PermissionsApplication = ({ t }) => {
+const AppPermissions = ({ t }) => {
   const { slug: slugName } = useParams()
   const THIRTY_SECONDS = 30 * 1000
 
@@ -161,4 +161,4 @@ const PermissionsApplication = ({ t }) => {
   )
 }
 
-export default withAllLocales(PermissionsApplication)
+export default withAllLocales(AppPermissions)

--- a/src/components/Permissions/AppPermissions/AppPermissions.spec.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.spec.jsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import PermissionsApplication from './AppPermissions'
+import AppPermissions from './AppPermissions'
 import {
   Q,
   useQuery,
@@ -92,7 +92,7 @@ jest.mock('cozy-client/dist/hooks/useFetchJSON', () => ({
   default: jest.fn()
 }))
 
-describe('PermissionsApplication', () => {
+describe('AppPermissions', () => {
   beforeEach(() => {
     const queryResult = {
       fetchStatus: 'loaded',
@@ -138,26 +138,26 @@ describe('PermissionsApplication', () => {
   it('should display slugName when query has been loaded', () => {
     hasQueryBeenLoaded.mockReturnValue(true)
     useFetchJSON.mockReturnValue({ data: ['doctype1', 'doctype2'] })
-    const { container } = render(<PermissionsApplication />)
+    const { container } = render(<AppPermissions />)
     expect(container).toMatchSnapshot()
   })
 
   it('should render a spinner when query is loading and has not been loaded', () => {
     isQueryLoading.mockReturnValue(true)
     hasQueryBeenLoaded.mockReturnValue(false)
-    const { queryByTestId } = render(<PermissionsApplication />)
+    const { queryByTestId } = render(<AppPermissions />)
     expect(queryByTestId('Spinner')).toBeTruthy()
   })
 
   it('should display slugName when query is not loading', () => {
     isQueryLoading.mockReturnValue(false)
-    const { queryByText } = render(<PermissionsApplication />)
+    const { queryByText } = render(<AppPermissions />)
     expect(queryByText('DRIVE')).toBeInTheDocument()
   })
 
   it('should render Permissions.failedRequest when query status is failed', () => {
     useQuery.mockReturnValue({ fetchStatus: 'failed' })
-    const { queryByText } = render(<PermissionsApplication />)
+    const { queryByText } = render(<AppPermissions />)
     expect(queryByText('Permissions.failedRequest')).toBeTruthy()
   })
 

--- a/src/components/Permissions/AppPermissions/__snapshots__/AppPermissions.spec.jsx.snap
+++ b/src/components/Permissions/AppPermissions/__snapshots__/AppPermissions.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PermissionsApplication should display slugName when query has been loaded 1`] = `
+exports[`AppPermissions should display slugName when query has been loaded 1`] = `
 <div>
   <div
     data-narrow="true"

--- a/src/components/Permissions/DataList/DataList.jsx
+++ b/src/components/Permissions/DataList/DataList.jsx
@@ -81,7 +81,7 @@ const DataList = ({ t }) => {
                         />
                       </ListItemIcon>
                       <ListItemText
-                        primary={t('CozyPermissions.Permissions.' + key)}
+                        primary={t('CozyPermissions.' + key)}
                         secondary={t('Permissions.numberOfApplications', {
                           smart_count: slugs.length
                         })}

--- a/src/components/Permissions/DataList/DataList.spec.jsx
+++ b/src/components/Permissions/DataList/DataList.spec.jsx
@@ -151,15 +151,15 @@ describe('DataList', () => {
     const { queryAllByTestId } = render(<DataList />)
     expect(queryAllByTestId('ListItemText')[0]).toHaveAttribute(
       'data-primary',
-      'CozyPermissions.Permissions.io.cozy.apps'
+      'CozyPermissions.io.cozy.apps'
     )
     expect(queryAllByTestId('ListItemText')[1]).toHaveAttribute(
       'data-primary',
-      'CozyPermissions.Permissions.io.cozy.files'
+      'CozyPermissions.io.cozy.files'
     )
     expect(queryAllByTestId('ListItemText')[2]).toHaveAttribute(
       'data-primary',
-      'CozyPermissions.Permissions.io.cozy.files.*'
+      'CozyPermissions.io.cozy.files.*'
     )
   })
 

--- a/src/components/Permissions/DataPermissions/DataPermissions.jsx
+++ b/src/components/Permissions/DataPermissions/DataPermissions.jsx
@@ -104,12 +104,12 @@ const DataPermissions = ({ t }) => {
               size={mediumSize}
             />
             <PageTitle>
-              {t('CozyPermissions.Permissions.' + permission).toUpperCase()}
+              {t('CozyPermissions.' + permission).toUpperCase()}
             </PageTitle>
             <Typography variant="body1" className="u-mb-1-half">
               {t('Permissions.access') +
                 ' ' +
-                t('CozyPermissions.Permissions.' + permission).toLowerCase()}
+                t('CozyPermissions.' + permission).toLowerCase()}
             </Typography>
           </div>
           <NavigationList>

--- a/src/components/Permissions/DataPermissions/__snapshots__/DataPermissions.spec.jsx.snap
+++ b/src/components/Permissions/DataPermissions/__snapshots__/DataPermissions.spec.jsx.snap
@@ -64,12 +64,12 @@ exports[`DataPermissions should display DataPermissions 1`] = `
       <div
         data-testid="page-title"
       >
-        COZYPERMISSIONS.PERMISSIONS.IO.COZY.FILES
+        COZYPERMISSIONS.IO.COZY.FILES
       </div>
       <p
         class="MuiTypography-root u-mb-1-half MuiTypography-body1 MuiTypography-colorTextPrimary"
       >
-        Permissions.access cozypermissions.permissions.io.cozy.files
+        Permissions.access cozypermissions.io.cozy.files
       </p>
     </div>
     <div

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -445,16 +445,17 @@
     "readAndWrite": "Read and Write",
     "write": "Write",
     "numberOfPermissions": "%{smart_count} permission |||| %{smart_count} permissions",
+    "numberOfApplications": "%{smart_count} application |||| %{smart_count} applications",
     "applications": "Applications",
     "data": "Data",
     "open": "Open",
     "access": "Applications with this permission can access your ",
     "about": "About",
-    "limited_right_access": "Limited right access",
+    "limited_right_access": "Local data permissions",
     "latest_data_releases": "Latest data releases",
     "monthly_statistics": "Monthly statistics",
     "monthly_stats_phrase": "Data release report from your cozy to %{app} on %{date}:",
-    "exit_rights": "Exit rights"
+    "exit_rights": "Latest outgoing data history"
   },
   "Accessibility": {
     "previous": "Previous"


### PR DESCRIPTION
- Translation was not showing in DataList and DataPermissions due to a change in cozy-client (removed '.Permissions' to access a doctype)
- Change translations of section titles in AppPermissions
- Add english translation for "number of applications" in DataList
- Rename "PermissionsApplications" to "AppPermissions" to match file name