### PR TITLE
feat: Filter 'last outgoing data history' section elements

### DIFF
--- a/src/components/Permissions/AppPermissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.jsx
@@ -10,9 +10,9 @@ import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
-import { OpenappButton } from '../OpenappButton'
-import { AboutButton } from '../AboutButton'
-import withAllLocales from '../../../lib/withAllLocales'
+import { OpenappButton } from 'components/Permissions/OpenappButton'
+import { AboutButton } from 'components/Permissions/AboutButton'
+import withAllLocales from 'lib/withAllLocales'
 import NavigationList from 'cozy-ui/transpiled/react/NavigationList'
 import CozyClient, {
   Q,
@@ -20,13 +20,14 @@ import CozyClient, {
   isQueryLoading,
   hasQueryBeenLoaded
 } from 'cozy-client'
-import AccessRightsSection from '../AccessRightsSection'
-import LatestDataReleases from '../LatestDataReleases'
+import AccessRightsSection from 'components/Permissions/AccessRightsSection'
+import LatestOutgoingDataHistory from 'components/Permissions/LatestOutgoingDataHistory'
 import {
   filterPermissions,
   sortPermissionsByName,
-  completeAppPermission
-} from '../helpers/permissionsHelper'
+  completeAppPermission,
+  filterRemoteRequests
+} from 'components/Permissions/helpers/permissionsHelper'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 
 const AppPermissions = ({ t }) => {
@@ -86,6 +87,11 @@ const AppPermissions = ({ t }) => {
   )
 
   const isKonnector = type => type === 'io.cozy.konnectors'
+
+  const filteredRemoteRequests = filterRemoteRequests(
+    queryResultRemoteRequests,
+    slugName
+  )
 
   return (
     <Page narrow>
@@ -147,9 +153,9 @@ const AppPermissions = ({ t }) => {
               />
             )}
 
-            {queryResultRemoteRequests.data.length > 0 && (
-              <LatestDataReleases
-                queryResultRemoteRequests={queryResultRemoteRequests}
+            {filteredRemoteRequests?.length > 0 && (
+              <LatestOutgoingDataHistory
+                queryResultRemoteRequests={filteredRemoteRequests}
                 slugName={slugName}
                 t={t}
               />

--- a/src/components/Permissions/LatestOutgoingDataHistory.jsx
+++ b/src/components/Permissions/LatestOutgoingDataHistory.jsx
@@ -15,9 +15,13 @@ import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListI
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import { isNotLastItem, sortDataByDate } from './helpers/permissionsHelper'
 import { Dialog as DialogComponent } from 'cozy-ui/transpiled/react/CozyDialogs'
-import withAllLocales from './../../lib/withAllLocales'
+import withAllLocales from '../../lib/withAllLocales'
 
-const LatestDataReleases = ({ queryResultRemoteRequests, slugName, t }) => {
+const LatestOutgoingDataHistory = ({
+  queryResultRemoteRequests,
+  slugName,
+  t
+}) => {
   const [modalOpened, setModalOpened] = useState(false)
   const [modalData, setModalData] = useState()
 
@@ -59,7 +63,7 @@ const LatestDataReleases = ({ queryResultRemoteRequests, slugName, t }) => {
                   />
                 </ListItemIcon>
                 <ListItemText
-                  primary={t('Permissions.monthly_statistics')}
+                  primary={t(`CozyPermissions.${data.doctype}`)}
                   secondary={formatDate({
                     f,
                     date: new Date(data.created_at)
@@ -108,4 +112,4 @@ const LatestDataReleases = ({ queryResultRemoteRequests, slugName, t }) => {
   )
 }
 
-export default withAllLocales(LatestDataReleases)
+export default withAllLocales(LatestOutgoingDataHistory)

--- a/src/components/Permissions/helpers/permissionsHelper.js
+++ b/src/components/Permissions/helpers/permissionsHelper.js
@@ -102,7 +102,15 @@ export const completeAppPermission = (
 }
 
 export const sortDataByDate = queryResult => {
-  return queryResult.data.sort(
+  return queryResult.sort(
     (a, b) => new Date(b.created_at) - new Date(a.created_at)
   )
+}
+
+export const filterRemoteRequests = (remoteRequests, slugName) => {
+  if (remoteRequests.data?.length > 0) {
+    return remoteRequests.data.filter(
+      data => data.cozyMetadata.createdByApp === slugName
+    )
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -452,10 +452,10 @@
     "access": "Applications with this permission can access your ",
     "about": "About",
     "limited_right_access": "Local data permissions",
-    "latest_data_releases": "Latest data releases",
+    "latest_data_releases": "Latest outgoing data history",
     "monthly_statistics": "Monthly statistics",
     "monthly_stats_phrase": "Data release report from your cozy to %{app} on %{date}:",
-    "exit_rights": "Latest outgoing data history"
+    "exit_rights": "Outgoing data permissions"
   },
   "Accessibility": {
     "previous": "Previous"


### PR DESCRIPTION
- Before, all remote requests elements were shown in 'Last outgoing data history' section, now only items created by the current app are shown
- Before "Monthly Stats" was the name of all remote requests elements, now it is the name of the doctype
- Renamed this section's file name 
![Capture d’écran 2022-11-02 à 16 42 32](https://user-images.githubusercontent.com/61142137/199534768-3361a136-8014-45ae-854e-0b4c55795e33.png)
