### PR TITLE
fix: Add overlay to UI when using biometry

### DIFF
--- a/src/components/pages/LockScreen.tsx
+++ b/src/components/pages/LockScreen.tsx
@@ -74,15 +74,33 @@ export const LockScreen = (): JSX.Element => {
         return setBiometryDeniedDialogVisible(true)
       }
 
+      if (!biometryEnabled && flagshipMetadata.platform?.OS === 'android')
+        await webviewIntent.call('setFlagshipUI', {
+          bottomOverlay: 'rgba(0,0,0,0.5)',
+          topOverlay: 'rgba(0,0,0,0.5)'
+        })
+
       const value = await handleChange(
         setBiometry,
         'biometryLock',
         webviewIntent
       )
+
       value && setAutoLock(true)
+
+      if (!biometryEnabled && flagshipMetadata.platform?.OS === 'android')
+        await webviewIntent.call('setFlagshipUI', {
+          bottomOverlay: 'transparent',
+          topOverlay: 'transparent'
+        })
     }
 
-    void doOnBiometryLock()
+    doOnBiometryLock().catch(onrejected =>
+      logger.error(
+        `Error while calling onBiometryLock(), see error:`,
+        onrejected
+      )
+    )
   }
 
   const onPinCodeLock = async (pinCode?: string): Promise<void> => {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,7 +1,7 @@
 import minilog from '@cozy/minilog'
 
 /**
- * @typedef {{ error: (arg: string) => void }} Logger
+ * @typedef {{ error: (...data: any[]) => void }} Logger
  * @type {Logger}
  */
 const logger = minilog(`cozy-settings`)


### PR DESCRIPTION
### Feature

Biometry settings on mobile app

### Context

The biometry input wasn't triggering any bar overlay change, they stayed white

### Implementation

Adding (for Android only as iOS doesn't have the issues) setFlagshipUI calls on open/close of the biometry prompt

### Testing

Manual only

### Screenshots

![image](https://user-images.githubusercontent.com/12577784/200609548-07c8dec6-1eb2-4a41-9695-a4dd282445c2.png)

### Thoughts

Code is verbose as is usual with setFlagshipUi but this topic can't be tackled in a bug fix