### PR TITLE
refactor: Do not wrap async method in React's EventHandler

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,7 +26,7 @@ import { useOffersLink } from 'hooks/useOffersLink'
 export const Sidebar = (): JSX.Element => {
   const { t } = useI18n()
   const percent = useDiskPercentage()
-  const logout = useLogout()
+  const logoutAndForget = useLogout()
   const offersLink = useOffersLink()
 
   return (
@@ -102,7 +102,7 @@ export const Sidebar = (): JSX.Element => {
           <MenuItemButton
             primary={t('Nav.primary_logout')}
             icon={Logout}
-            onClick={(): void => void logout()}
+            onClick={logoutAndForget}
           />
         </MenuList>
       </List>

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -4,17 +4,21 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import { useClient } from 'cozy-client'
 import { useWebviewIntent } from 'cozy-intent'
 
-export const useLogout = (): (() => Promise<void>) => {
+export const useLogout = (): (() => void) => {
   const client = useClient()
   const webviewIntent = useWebviewIntent()
 
-  const logout = useCallback(async () => {
-    await client.logout()
+  const logoutAndForget = useCallback(() => {
+    const doLogout = async (): Promise<boolean | void | null> => {
+      await client.logout()
 
-    return isFlagshipApp() && webviewIntent
-      ? webviewIntent.call('logout')
-      : window.location.reload()
+      return isFlagshipApp() && webviewIntent
+        ? webviewIntent.call('logout')
+        : window.location.reload()
+    }
+
+    return void doLogout()
   }, [client, webviewIntent])
 
-  return logout
+  return logoutAndForget
 }


### PR DESCRIPTION
This is a test of refactoring to check how we can mitigate the `no-misused-promise` ESLint error.