### PR TITLE
fix: add `percent` variable in EN locale

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,7 +89,7 @@
     "primary_wifi_sync": "Sync only on wifi",
     "profile": "Profile",
     "secondary_free": "Free",
-    "secondary_used": "used",
+    "secondary_used": "%{percent}% used",
     "sessions": "Connections",
     "storage": "Storage"
   },


### PR DESCRIPTION
The variable wasn't put in the english json file. It will now work as
in the French version.

See: https://github.com/cozy/cozy-settings/blob/7c21722945f367722b9512e5a4883f874107b9fb/src/locales/fr.json#L92