### PR TITLE
feat: pinCode activation also sets autoLock to true

### DIFF
--- a/src/components/pages/LockScreen.tsx
+++ b/src/components/pages/LockScreen.tsx
@@ -106,12 +106,14 @@ export const LockScreen = (): JSX.Element => {
   const onPinCodeLock = async (pinCode?: string): Promise<void> => {
     if (!pinCodeEnabled && !pinCode) return setPinModalVisible(true)
 
-    await handleChange(
+    const value = await handleChange(
       setPinCode,
       'PINLock',
       webviewIntent,
       pinCode ? { pinCode } : undefined
     )
+
+    value && setAutoLock(true)
 
     pinCode && setPinModalVisible(false)
   }


### PR DESCRIPTION
This is a new feature, making pinCode behaves like biometry.
When they are activated, autoLock gets automatically activated too.