### PR TITLE
fix: reorder flagship specific menu

### DIFF
--- a/src/components/menu/MenuItemAnchor.tsx
+++ b/src/components/menu/MenuItemAnchor.tsx
@@ -26,7 +26,7 @@ export const MenuItemAnchor = ({
       <Icon icon={icon} />
     </ListItemIcon>
 
-    <ListItemText primary={primary} secondary={secondary} />
+    <ListItemText ellipsis={false} primary={primary} secondary={secondary} />
 
     {target === '_blank' && <Icon icon={OpenwithIcon} />}
   </ListItem>

--- a/src/components/menu/MenuItemButton.tsx
+++ b/src/components/menu/MenuItemButton.tsx
@@ -23,6 +23,6 @@ export const MenuItemButton = ({
       <Icon icon={icon} />
     </ListItemIcon>
 
-    <ListItemText primary={primary} secondary={secondary} />
+    <ListItemText ellipsis={false} primary={primary} secondary={secondary} />
   </ListItem>
 )

--- a/src/components/menu/MenuItemNavLink.tsx
+++ b/src/components/menu/MenuItemNavLink.tsx
@@ -44,7 +44,7 @@ export const MenuItemNavLink = (props: MenuItemNavLinkProps): JSX.Element => {
         <Icon icon={icon} />
       </ListItemIcon>
 
-      <ListItemText primary={primary} secondary={secondary} />
+      <ListItemText ellipsis={false} primary={primary} secondary={secondary} />
 
       {beforeEnd}
 

--- a/src/components/menu/MenuItemSwitch.tsx
+++ b/src/components/menu/MenuItemSwitch.tsx
@@ -29,7 +29,7 @@ export const MenuItemSwitch = ({
       <Icon icon={icon} />
     </ListItemIcon>
 
-    <ListItemText primary={primary} secondary={secondary} />
+    <ListItemText ellipsis={false} primary={primary} secondary={secondary} />
 
     <Switch checked={checked} color="primary" />
   </ListItem>

--- a/src/components/pages/LockScreen.tsx
+++ b/src/components/pages/LockScreen.tsx
@@ -127,6 +127,13 @@ export const LockScreen = (): JSX.Element => {
 
       <nav>
         <List>
+          <MenuItemSwitch
+            checked={autoLockEnabled}
+            icon={Swap}
+            onClick={onAutoLock}
+            primary={t('Nav.primary_lock_switch')}
+          />
+
           {showBiometryOption && (
             <MenuItemSwitch
               primary={
@@ -149,13 +156,6 @@ export const LockScreen = (): JSX.Element => {
             icon={Password}
             onClick={(): void => void onPinCodeLock()}
             primary={t('Nav.primary_pin_switch')}
-          />
-
-          <MenuItemSwitch
-            checked={autoLockEnabled}
-            icon={Swap}
-            onClick={onAutoLock}
-            primary={t('Nav.primary_lock_switch')}
           />
         </List>
       </nav>


### PR DESCRIPTION
Also, disable the ellipsis on all buttons as they are intended for small screens.

![image](https://user-images.githubusercontent.com/12577784/211336143-40db0c61-4ad5-4fe3-973b-cad7f510e720.png)