### PR TITLE
fix: Correctly handle navigation when clicking on permission back button

### DIFF
--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -16,10 +16,10 @@ const barTitleStyle = { height: '3rem', display: 'flex', alignItems: 'center' }
 const BarContainer = ({ children }) => {
   return <div style={barTitleStyle}>{children}</div>
 }
-const PageTitle = ({ children, ...rest }) => {
+const PageTitle = ({ children, backButtonPath, ...rest }) => {
   const isRoot = useMatch('/menu')
   const navigate = useNavigate()
-  const navigateBack = () => navigate('..')
+  const navigateBack = () => navigate(backButtonPath ? backButtonPath : '..')
   const { isMobile, isTablet } = useBreakpoints()
   const { t } = useI18n()
 

--- a/src/components/Permissions/AppPermissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.jsx
@@ -128,7 +128,10 @@ const AppPermissions = ({ t }) => {
               <div style={{ width: '48px' }}>
                 <AppIcon app={slugName} />
               </div>
-              <PageTitle className={isMobile || isTablet ? '' : 'u-mh-1'}>
+              <PageTitle
+                className={isMobile || isTablet ? '' : 'u-mh-1'}
+                backButtonPath="/permissions/slug"
+              >
                 {slugName.toUpperCase()}
               </PageTitle>
             </div>

--- a/src/components/Permissions/DataPermissions/DataPermissions.jsx
+++ b/src/components/Permissions/DataPermissions/DataPermissions.jsx
@@ -93,7 +93,7 @@ const DataPermissions = ({ t }) => {
               }
               size={mediumSize}
             />
-            <PageTitle>
+            <PageTitle backButtonPath="/permissions/data">
               {t('CozyPermissions.' + permission).toUpperCase()}
             </PageTitle>
             <Typography variant="body1" className="u-mb-1-half">


### PR DESCRIPTION
With previous implémentation, clicking on the cozy-bar's back button on mobile view would navigate from `#/permissions/slug/:slug` to `#/menu` instead of `#/permissions/slug`

This commit is an attempt to fix the back button behaviour on `AppPermissions.jsx` until we find a more generic way