### PR TITLE
fix: Use grid instead of flexbox for AppPermissions title actions

### DIFF
--- a/src/components/Permissions/AppPermissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.jsx
@@ -33,6 +33,12 @@ import { useQuery } from 'cozy-client'
 import { UninstallButton } from '../UninstallButton'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
+const styles = {
+  actionButtons: {
+    gap: '2em'
+  }
+}
+
 const AppPermissions = ({ t }) => {
   const { slug: slugName } = useParams()
   const { isMobile, isTablet } = useBreakpoints()
@@ -133,25 +139,21 @@ const AppPermissions = ({ t }) => {
               </PageTitle>
             </div>
             <div
-              className={classNames(
-                'u-flex u-flex-column u-flex-items-center',
-                {
-                  'u-mt-1': isMobile || isTablet
-                }
-              )}
+              className={classNames('u-flex u-flex-row u-flex-items-center', {
+                'u-mt-1': isMobile || isTablet
+              })}
+              style={styles.actionButtons}
             >
-              <div>
-                <OpenappButton
-                  type={
-                    isKonnector(matchingQueryResult.data.type)
-                      ? 'konnector'
-                      : 'app'
-                  }
-                  appData={matchingQueryResult.data}
-                />
-                <AboutButton appData={matchingQueryResult.data} />
-                <UninstallButton appData={matchingQueryResult.data} />
-              </div>
+              <OpenappButton
+                type={
+                  isKonnector(matchingQueryResult.data.type)
+                    ? 'konnector'
+                    : 'app'
+                }
+                appData={matchingQueryResult.data}
+              />
+              <AboutButton appData={matchingQueryResult.data} />
+              <UninstallButton appData={matchingQueryResult.data} />
             </div>
           </div>
           <NavigationList

--- a/src/components/Permissions/AppPermissions/__snapshots__/AppPermissions.spec.jsx.snap
+++ b/src/components/Permissions/AppPermissions/__snapshots__/AppPermissions.spec.jsx.snap
@@ -59,19 +59,18 @@ exports[`AppPermissions should display slugName when query has been loaded 1`] =
           </div>
         </div>
         <div
-          class="u-flex u-flex-column u-flex-items-center"
+          class="u-flex u-flex-row u-flex-items-center"
+          style="gap: 2em;"
         >
-          <div>
-            <div
-              data-testid="CircleButton"
-            />
-            <div
-              data-testid="CircleButton"
-            />
-            <div
-              data-testid="CircleButton"
-            />
-          </div>
+          <div
+            data-testid="CircleButton"
+          />
+          <div
+            data-testid="CircleButton"
+          />
+          <div
+            data-testid="CircleButton"
+          />
         </div>
       </div>
       <div


### PR DESCRIPTION
On `AppPermissions.jsx` we want a specific gap between title's actions buttons

Cozy's class utilities does not give any class for handling Flexbox's gap, so instead this commit uses a Grid component with `spacing` instruction

### Before
![image](https://user-images.githubusercontent.com/1884255/213772433-85808699-0661-4aa5-8763-377c03073858.png)

### After
![image](https://user-images.githubusercontent.com/1884255/213772521-f37027e6-766b-4f3a-b532-79a21ce95824.png)
