### PR TITLE
fix: Use displayName instead of Slug

### DIFF
--- a/src/components/Permissions/AppPermissions/AppPermissions.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.jsx
@@ -4,6 +4,8 @@ import classNames from 'classnames'
 
 import { useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
 import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
+import { getAppDisplayName } from 'cozy-client/dist/models/applications'
+
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
@@ -117,7 +119,9 @@ const AppPermissions = ({ t }) => {
                 className={isMobile || isTablet ? '' : 'u-mh-1'}
                 backButtonPath="/permissions/slug"
               >
-                {slugName.toUpperCase()}
+                {result.data.name
+                  ? getAppDisplayName(result.data).toUpperCase()
+                  : slugName.toUpperCase()}
               </PageTitle>
             </div>
             <div

--- a/src/components/Permissions/AppPermissions/AppPermissions.spec.jsx
+++ b/src/components/Permissions/AppPermissions/AppPermissions.spec.jsx
@@ -172,18 +172,24 @@ describe('AppPermissions', () => {
     expect(queryByTestId('Spinner')).toBeTruthy()
   })
 
-  it('should display slugName when query is not loading', () => {
+  it('should display appName when query is not loading', () => {
     useAppsOrKonnectorsBySlug.mockReturnValue({
       isResultLoading: false,
       hasQueryFailed: false,
-      result: { fetchStatus: 'loaded', data: {} }
+      result: {
+        fetchStatus: 'loaded',
+        data: {
+          name: 'Drive',
+          name_prefix: 'Coz'
+        }
+      }
     })
     const { queryByText } = render(
       <BreakpointsProvider>
         <AppPermissions />
       </BreakpointsProvider>
     )
-    expect(queryByText('DRIVE')).toBeInTheDocument()
+    expect(queryByText('Coz Drive'.toUpperCase())).toBeInTheDocument()
   })
 
   it('should render Permissions.failedRequest when query status is failed', () => {

--- a/src/components/Permissions/PermissionDetails/PermissionDetails.tsx
+++ b/src/components/Permissions/PermissionDetails/PermissionDetails.tsx
@@ -1,14 +1,31 @@
 import React, { FunctionComponent } from 'react'
 import { useParams } from 'react-router-dom'
 
+import { getAppDisplayName } from 'cozy-client/dist/models/applications'
+
+import useAppsOrKonnectorsBySlug from 'components/Permissions/hooks/useAppsOrKonnectorsBySlug'
+
 import PermissionDetailsModal from 'components/Permissions/PermissionDetails/PermissionDetailsModal'
 
 const PermissionDetails: FunctionComponent = () => {
   const { slug, permissionType } = useParams()
-
-  if (slug && permissionType) {
+  const { isResultLoading, hasQueryFailed, result } =
+    useAppsOrKonnectorsBySlug(slug)
+  if (
+    !isResultLoading &&
+    !hasQueryFailed &&
+    result?.data &&
+    slug &&
+    permissionType
+  ) {
     return (
-      <PermissionDetailsModal slug={slug} permissionType={permissionType} />
+      <PermissionDetailsModal
+        slug={slug}
+        permissionType={permissionType}
+        // @ts-expect-error unsafe assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        appName={getAppDisplayName(result.data)}
+      />
     )
   }
 

--- a/src/components/Permissions/PermissionDetails/PermissionDetailsModal.jsx
+++ b/src/components/Permissions/PermissionDetails/PermissionDetailsModal.jsx
@@ -9,7 +9,7 @@ import withAllLocales from 'lib/withAllLocales'
 import useAppsOrKonnectorsBySlug from 'components/Permissions/hooks/useAppsOrKonnectorsBySlug'
 import PermissionDetailsModalContent from 'components/Permissions/PermissionDetails/PermissionDetailsModalContent'
 
-const PermissionDetailsModal = ({ slug, permissionType, t }) => {
+const PermissionDetailsModal = ({ slug, permissionType, t, appName }) => {
   const navigate = useNavigate()
 
   const closeModal = () => {
@@ -48,11 +48,11 @@ const PermissionDetailsModal = ({ slug, permissionType, t }) => {
       title={title}
       content={
         <PermissionDetailsModalContent
-          slug={slug}
           verbs={permission.verbs}
           description={permission.description}
           isRemoteDoctypes={isRemoteDoctypes}
           title={title}
+          appName={appName}
           t
         />
       }

--- a/src/components/Permissions/PermissionDetails/PermissionDetailsModalContent.jsx
+++ b/src/components/Permissions/PermissionDetails/PermissionDetailsModalContent.jsx
@@ -7,11 +7,11 @@ import withAllLocales from 'lib/withAllLocales'
 import { displayPermissions } from 'components/Permissions/helpers/permissionsHelper'
 
 const PermissionDetailsModalContent = ({
-  slug,
   verbs,
   description,
   isRemoteDoctypes,
   title,
+  appName,
   t
 }) => {
   const displayedPermissions = displayPermissions(verbs)
@@ -28,11 +28,11 @@ const PermissionDetailsModalContent = ({
       <Typography variant="h5" className="">
         {isRemoteDoctypes
           ? t('Permissions.exit_right', {
-              app: slug.toUpperCase(),
+              app: appName.toUpperCase(),
               doctype: title.toLowerCase()
             })
           : t('Permissions.access_right', {
-              app: slug.toUpperCase(),
+              app: appName.toUpperCase(),
               doctype: title.toLowerCase()
             })}
       </Typography>
@@ -43,11 +43,11 @@ const PermissionDetailsModalContent = ({
         {isRemoteDoctypes
           ? t('Permissions.exit_right_description')
           : t('Permissions.access_right_description', {
-              app: slug.toUpperCase()
+              app: appName.toUpperCase()
             })}
       </Alert>
       <Typography variant="h5" className="u-mt-1-half">
-        {t('Permissions.right_reason', { app: slug.toUpperCase() })}
+        {t('Permissions.right_reason', { app: appName.toUpperCase() })}
       </Typography>
       <Typography className="u-mt-half">{description}</Typography>
       <Typography variant="h5" className="u-mt-1-half">


### PR DESCRIPTION
We displayed the technical name (slug) to the end user. We fixed it, by display the right thing to the user

Before: 
<img width="1552" alt="Capture d’écran 2023-02-24 à 10 47 17" src="https://user-images.githubusercontent.com/1107936/221147418-8a806c81-f6f1-4b4d-be94-89951d4e90d3.png">
<img width="1552" alt="Capture d’écran 2023-02-24 à 10 47 21" src="https://user-images.githubusercontent.com/1107936/221147434-d045fab9-bae3-48b0-852e-8a231bd13d88.png">


After:

![Capture d’écran 2023-02-24 à 10 48 29](https://user-images.githubusercontent.com/1107936/221147487-a741ba53-bff2-4e3c-b286-5bc92d2326aa.png)
![Capture d’écran 2023-02-24 à 10 48 32](https://user-images.githubusercontent.com/1107936/221147494-e0fc9496-1d40-40ef-ae4d-e0a56a40816b.png)
