### PR TITLE
feat: send a react-native message on setLang

### DIFF
--- a/src/components/LanguageSection.jsx
+++ b/src/components/LanguageSection.jsx
@@ -4,6 +4,7 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Select from 'components/Select'
+import { useSetLang } from 'hooks/useSetLang'
 
 const LANG_OPTIONS = ['en', 'fr', 'es']
 
@@ -17,6 +18,10 @@ const LanguageSection = props => {
   }
   const selectedLocale = fields.locale.value
   const fieldName = 'locale'
+
+  // Flagship App side-effect to set the locale
+  useSetLang(selectedLocale)
+
   return (
     <div>
       <Select

--- a/src/hooks/useSetLang.spec.tsx
+++ b/src/hooks/useSetLang.spec.tsx
@@ -1,0 +1,113 @@
+import { render, act } from '@testing-library/react'
+import { useSetLang } from './useSetLang'
+import React from 'react'
+
+const mockWebviewIntent = {
+  call: jest.fn().mockResolvedValue(true)
+}
+
+jest.mock('cozy-intent', () => ({
+  useWebviewIntent: (): { call: () => Promise<boolean> } => mockWebviewIntent
+}))
+
+// Create a dummy component to wrap the useSetLang hook
+const DummyComponent = ({
+  selectedLocale
+}: {
+  selectedLocale?: string | null
+}): null => {
+  useSetLang(selectedLocale)
+  return null
+}
+
+describe('useSetLang', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls webviewIntent.call when selectedLocale changes', () => {
+    // Initial render with selectedLocale set to 'en'
+    const { rerender } = render(<DummyComponent selectedLocale="en" />)
+
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+
+    // Update selectedLocale to 'fr'
+    act(() => {
+      rerender(<DummyComponent selectedLocale="fr" />)
+    })
+
+    expect(mockWebviewIntent.call).toHaveBeenCalledWith('setLang', 'fr')
+  })
+
+  it('does not call webviewIntent.call when selectedLocale is null or undefined', () => {
+    const { rerender } = render(<DummyComponent selectedLocale={null} />)
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+
+    act(() => {
+      rerender(<DummyComponent selectedLocale={undefined} />)
+    })
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+  })
+
+  it('does not call webviewIntent.call when selectedLocale does not change', () => {
+    const { rerender } = render(<DummyComponent selectedLocale="en" />)
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+
+    act(() => {
+      rerender(<DummyComponent selectedLocale="en" />)
+    })
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+  })
+
+  it('calls webviewIntent.call with correct arguments when selectedLocale changes multiple times', () => {
+    const { rerender } = render(<DummyComponent selectedLocale="en" />)
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+
+    act(() => {
+      rerender(<DummyComponent selectedLocale="fr" />)
+    })
+    expect(mockWebviewIntent.call).toHaveBeenCalledWith('setLang', 'fr')
+
+    act(() => {
+      rerender(<DummyComponent selectedLocale="es" />)
+    })
+    expect(mockWebviewIntent.call).toHaveBeenCalledWith('setLang', 'es')
+  })
+
+  it('handles failure when calling webviewIntent.call', () => {
+    mockWebviewIntent.call.mockRejectedValue(
+      new Error('Failed to set language')
+    )
+
+    expect(() => {
+      render(<DummyComponent selectedLocale="en" />)
+    }).not.toThrow()
+  })
+
+  it('does not throw error when webviewIntent is undefined', () => {
+    jest.mock('cozy-intent', () => ({
+      useWebviewIntent: (): undefined => undefined
+    }))
+
+    expect(() => {
+      render(<DummyComponent selectedLocale="en" />)
+    }).not.toThrow()
+  })
+
+  it('calls webviewIntent.call when selectedLocale changes from undefined to a string', async () => {
+    // Initial render with selectedLocale set to 'undefined'
+    const { rerender } = render(<DummyComponent selectedLocale={undefined} />)
+
+    expect(mockWebviewIntent.call).not.toHaveBeenCalled()
+
+    // Update selectedLocale to 'fr'
+    act(() => {
+      rerender(<DummyComponent selectedLocale="fr" />)
+    })
+
+    // Wait for any asynchronous actions to complete
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mockWebviewIntent.call).toHaveBeenCalledWith('setLang', 'fr')
+  })
+})

--- a/src/hooks/useSetLang.ts
+++ b/src/hooks/useSetLang.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+import { useWebviewIntent } from 'cozy-intent'
+import logger from 'lib/logger'
+
+export const useSetLang = (selectedLocale?: string | null): void => {
+  const webviewIntent = useWebviewIntent()
+  const prevLocale = useRef<undefined | string>()
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false // First render has been done
+    } else if (
+      selectedLocale !== undefined &&
+      selectedLocale !== null &&
+      selectedLocale !== prevLocale.current &&
+      webviewIntent
+    ) {
+      webviewIntent
+        .call('setLang', selectedLocale)
+        .then(() => {
+          prevLocale.current = selectedLocale
+          return { selectedLocale }
+        })
+        .catch(error => {
+          logger.error('Failed to set locale on Flagship app', error)
+        })
+    }
+  }, [selectedLocale, webviewIntent])
+}


### PR DESCRIPTION
This will allow the flagship app
to update its language on real time
when it has been successfully updated
from the cozy-settings app

using cozy-intent when current language is changing
listening to UI props to be in sync