### PR TITLE
feat: Hide pending OAuth clients in DevicesView

### DIFF
--- a/src/components/Devices/DevicesView.jsx
+++ b/src/components/Devices/DevicesView.jsx
@@ -55,7 +55,11 @@ const DevicesView = () => {
     () =>
       Array.isArray(data)
         ? data
-            .filter(device => DISPLAYED_CLIENTS.includes(device.client_kind))
+            .filter(
+              device =>
+                DISPLAYED_CLIENTS.includes(device.client_kind) &&
+                !device.pending
+            )
             .sort((a, b) => {
               return a.client_name.localeCompare(b.client_name, lang, {
                 sensitivity: 'base',

--- a/src/components/Devices/DevicesView.spec.jsx
+++ b/src/components/Devices/DevicesView.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+
+import { DevicesView } from './DevicesView'
+import AppLike from '../../../test/AppLike'
+import { OAUTH_CLIENTS_DOCTYPE } from 'doctypes'
+
+const pendingDevice = {
+  id: 'mock-device-pending',
+  _id: 'mock-device-pending',
+  _type: 'io.cozy.oauth.clients',
+  pending: true,
+  client_kind: 'desktop',
+  client_name: 'Mock Device Pending'
+}
+
+const connectedDevice = {
+  id: 'mock-device-connected',
+  _id: 'mock-device-connected',
+  _type: 'io.cozy.oauth.clients',
+  client_kind: 'desktop',
+  client_name: 'Mock Device Connected'
+}
+
+const sharingDevice = {
+  id: 'mock-device-sharing',
+  _id: 'mock-device-sharing',
+  _type: 'io.cozy.oauth.clients',
+  client_kind: 'sharing',
+  client_name: 'Mock Sharing xyz'
+}
+
+describe('DevicesView', () => {
+  const setup = ({ devices = [] }) => {
+    const mockClient = createMockClient({
+      queries: {
+        'io.cozy.oauth.clients _id asc': {
+          doctype: OAUTH_CLIENTS_DOCTYPE,
+          data: devices
+        }
+      }
+    })
+    return render(
+      <AppLike client={mockClient}>
+        <DevicesView />
+      </AppLike>
+    )
+  }
+
+  it('displays fully connected user devices only', () => {
+    setup({ devices: [pendingDevice, connectedDevice, sharingDevice] })
+
+    expect(screen.queryByText('Mock Device Connected')).toBeInTheDocument()
+    expect(screen.queryByText('Mock Device Pending')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mock Sharing xzy')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Pending OAuth clients are clients that are not fully configured yet
(e.g. permissions haven't been accepted yet).

We should hide these clients as they're not really relevant to the
user and we could even get into annoying situations like the user
revoking the client their trying to connect.

These clients are deleted after 1 hour if they're still pending.