### PR TITLE
fix: Set english translations for PIN code dialog

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -386,16 +386,16 @@
     "cancel": "Cancel"
   },
   "LockScreenView": {
-    "choose_pin_body": "choose_pin_body",
-    "choose_pin_cancel": "choose_pin_cancel",
-    "choose_pin_label": "choose_pin_label",
-    "choose_pin_next": "choose_pin_next",
-    "choose_pin_title": "choose_pin_title",
-    "confirm_pin_body": "confirm_pin_body",
-    "confirm_pin_cancel": "confirm_pin_cancel",
-    "confirm_pin_error": "confirm_pin_error",
-    "confirm_pin_next": "confirm_pin_next",
-    "confirm_pin_title": "confirm_pin_title",
+    "choose_pin_body": "Set your PIN to unlock the application after a period of inactivity",
+    "choose_pin_cancel": "Cancel",
+    "choose_pin_label": "PIN Code",
+    "choose_pin_next": "Next",
+    "choose_pin_title": "Choose a PIN code",
+    "confirm_pin_body": "For security reasons, please re-enter your PIN code.",
+    "confirm_pin_cancel": "Cancel",
+    "confirm_pin_error": "PIN codes do not match",
+    "confirm_pin_next": "Complete",
+    "confirm_pin_title": "Confirm PIN code",
     "title": "Unlock screen"
   },
   "soon": {


### PR DESCRIPTION
The PIN code dialog was not translated in english and was displayed with dummy strings. This PR fixes that by adding correct translations.

Here are the french vs english comparison to help reviewing translations in their own context.

First step:
![image](https://github.com/cozy/cozy-settings/assets/1884255/614fe139-9360-4a8b-8aa4-f45eafac34bf) ![image](https://github.com/cozy/cozy-settings/assets/1884255/16040a09-8393-4546-b216-4ee32f900d40)

Second step:
![image](https://github.com/cozy/cozy-settings/assets/1884255/63058309-707c-4c07-bf4a-f0c10c1b01f6) ![image](https://github.com/cozy/cozy-settings/assets/1884255/8a45ea9a-c9f6-4a9c-9782-8dd0bb1ba3e2)

