### PR TITLE
fix: Correctly display export dialog when there is no cursor

### DIFF
--- a/src/components/export/ExportDownload.jsx
+++ b/src/components/export/ExportDownload.jsx
@@ -65,20 +65,20 @@ class ExportDownload extends Component {
                     rightIcon="download"
                     onClick={() => this.download()}
                   />
-                  {cursors &&
-                    cursors.length &&
-                    cursors.map((cursor, index) => {
-                      return (
-                        <ButtonAction
-                          label={t('ProfileView.export.download.CTA_part', {
-                            number: index + 1
-                          })}
-                          rightIcon="download"
-                          onClick={() => this.download(cursor)}
-                          key={index}
-                        />
-                      )
-                    })}
+                  {cursors && cursors.length
+                    ? cursors.map((cursor, index) => {
+                        return (
+                          <ButtonAction
+                            label={t('ProfileView.export.download.CTA_part', {
+                              number: index + 1
+                            })}
+                            rightIcon="download"
+                            onClick={() => this.download(cursor)}
+                            key={index}
+                          />
+                        )
+                      })
+                    : null}
                 </div>
               )}
             </div>


### PR DESCRIPTION
When the export dialog may propose to download the Cozy's data in multiple parts

When doing so, a list of each available part is displayed

But when no part is available (i.e. only a single archive is proposed) then only the download button should be displayed

With previous implementation, the character `0` would have been displayed instead of an empty list

### Before
![image](https://github.com/cozy/cozy-settings/assets/1884255/d404d2c7-c82c-4633-914e-20a07a7107a2)

### After
![image](https://github.com/cozy/cozy-settings/assets/1884255/b793d276-1da1-4fee-ba30-1a6e618da30b)
