### PR TITLE
[VO-489] fix: Remove prefix into bar app name

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -29,7 +29,7 @@ export const App = () => {
     <Layout
       className={classNames({ [styles['Layout--small-view']]: isSmallView })}
     >
-      <BarComponent />
+      <BarComponent appNamePrefix={null} />
       {App.renderExtra()}
       <Alerter />
       {isBigView && <Sidebar />}


### PR DESCRIPTION

```
### 🐛 Bug Fixes

* Remove prefix into bar app name
```
