### PR TITLE
fix: Change PassphraseForm's buttons types for `submit`

### DIFF
--- a/src/components/PassphraseForm.jsx
+++ b/src/components/PassphraseForm.jsx
@@ -184,6 +184,7 @@ const PassphraseForm = ({ errors, submitting, saved, onSubmit }) => {
           label={t('PassphraseView.submit')}
           fullWidth
           className="u-mb-half"
+          type="submit"
         >
           {saved && <Icon className="u-ml-half u-valid" icon={CheckIcon} />}
         </Buttons>


### PR DESCRIPTION
In 3cfb9fcbda7f5f3292c88b1fc09d0b16b221e7da we migrated `react/deprecated/Button` to `react/Buttons`

Those 2 components have a different default behaviour

`react/deprecated/Button` would produce a button with type `submit` by default

`react/Buttons` would produce a button with type `button` by default

In `PassphraseForm` we expect the button to act as a `submit` as we are inside of a `<form>` element

As the new default type is `button`, the user cannot change their password anymore as the generated `button` would do nothing (there is no `onClick` instruction on it)

To fix this we want to explicitly ask for a `submit` type, so we rollback to the previous behaviour

Related commit: 3cfb9fcbda7f5f3292c88b1fc09d0b16b221e7da



```
### ✨ Features

*

### 🐛 Bug Fixes

* Fix a bug that prevented to change password from the Passphrase form

### 🔧 Tech

*
```
