### PR TITLE
chore: Remove useless installation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,10 @@ jobs:
         - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then eval "$(ssh-agent -s)"; fi
         - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then chmod 600 /tmp/id_rsa_downcloud_cozy-settings; fi
         - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then ssh-add /tmp/id_rsa_downcloud_cozy-settings; fi
-      before_deploy:
-        - yarn add cozy-app-publish # to be sure to have the last version before deploy
       deploy:
-      - provider: script
-        repo: cozy/cozy-settings
-        skip-cleanup: true
-        script: yarn semantic-release
-        on:
-          branch: master
+        - provider: script
+          repo: cozy/cozy-settings
+          skip-cleanup: true
+          script: yarn semantic-release
+          on:
+            branch: master

--- a/release.config.js
+++ b/release.config.js
@@ -8,7 +8,7 @@ module.exports = {
       {
         replacements: [
           {
-            files: ['manifest.webapp', 'package.json'],
+            files: ['manifest.webapp'],
             from: '"version": ".*"',
             to: '"version": "${nextRelease.version}"',
             results: [


### PR DESCRIPTION
The package `cozy-app-publish` is now a dev dependencie of this projet. These is to avoid commiting modification of package.json without the yarn-lock each time after installation into Travis script 