### PR TITLE
feat: Update cozy-ui to 110.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "cozy-realtime": "4.6.0",
     "cozy-sharing": "^15.0.0",
     "cozy-stack-client": "^48.2.0",
-    "cozy-ui": "^110.0.0",
+    "cozy-ui": "^110.1.0",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.8.1",
     "react": "18.2.0",

--- a/src/components/Devices/__snapshots__/DevicesModaleConfigureView.spec.jsx.snap
+++ b/src/components/Devices/__snapshots__/DevicesModaleConfigureView.spec.jsx.snap
@@ -4,7 +4,6 @@ exports[`DevicesModaleConfigureView when the folders query yields folders with h
 Object {
   "asFragment": [Function],
   "baseElement": <body
-    class="CozyTheme--light-normal"
     style="padding-right: 0px; overflow: hidden;"
   >
     <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -5685,10 +5685,10 @@ cozy-stack-client@^48.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^110.0.0:
-  version "110.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-110.0.0.tgz#5d39046abe6d1ea5ebcc309d389c56c94f975b65"
-  integrity sha512-DUb1KUpIRHqimkVCxdt9q2kBHsG6GCr1f+IiL87+Z3aokNeVRrG9+7UMC3LcFSPKvCr4Bhr3aFEVm+nCqUbRtA==
+cozy-ui@^110.1.0:
+  version "110.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-110.1.0.tgz#3881ca8945a41848558f8c8133d8fb611b1d6195"
+  integrity sha512-mjC1snnTFMOWbIa6pbqmeUuHCo0Fy+VieH6jLuMWrlz7cgi0pLqWQS3/B4qexkuF4v5DVqjGhc4krRz25If9Ig==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
To better support dark mode (flagship app and dark mode button in cozy-settings).



```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Update cozy-ui to 110.1.0 (better dark mode support)
```
