### PR TITLE
[VO-780] fix: Enforce stronger encryption for new password hashing

### DIFF
--- a/src/actions/passphrase.js
+++ b/src/actions/passphrase.js
@@ -20,6 +20,8 @@ export const UPDATE_HINT = 'UPDATE_HINT'
 export const UPDATE_HINT_SUCCESS = 'UPDATE_HINT_SUCCESS'
 export const UPDATE_HINT_FAILURE = 'UPDATE_HINT_FAILURE'
 
+const KDF_ITERATIONS = 650000
+
 const invalidPassphraseErrorAction = {
   type: UPDATE_PASSPHRASE_FAILURE,
   errors: {
@@ -76,7 +78,8 @@ export const updatePassphrase = (
 
       const newHashAndKeys = await vaultClient.computeNewHashAndKeys(
         currentPassphrase,
-        newPassphrase
+        newPassphrase,
+        KDF_ITERATIONS
       )
       await cozyFetch(client, 'PUT', '/settings/passphrase', {
         current_passphrase: newHashAndKeys.currentPasswordHash,
@@ -154,7 +157,8 @@ export const updatePassphrase2FASecond = (
       await vaultClient.login(currentPassphrase)
       const newHashAndKeys = await vaultClient.computeNewHashAndKeys(
         currentPassphrase,
-        newPassphrase
+        newPassphrase,
+        KDF_ITERATIONS
       )
       await cozyFetch(client, 'PUT', '/settings/passphrase', {
         new_passphrase: newHashAndKeys.newPasswordHash,


### PR DESCRIPTION
Previously, we attempted to hash the new password using the same encryption parameters as the initial password. In cases where the initial password was hashed with low kdf iterations, this led to server rejections. Thus commit fore a higher kdf iterations for new passwords to ensure compatibility with server requirements

```
### 🐛 Bug Fixes

* Enforce stronger encryption for new password hashing
```