### PR TITLE
chore: Update cozy-ui to version 124.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "cozy-search": "^0.6.0",
     "cozy-sharing": "^25.4.0",
     "cozy-stack-client": "^57.2.0",
-    "cozy-ui": "^123.2.0",
+    "cozy-ui": "^124.2.0",
     "identity-obj-proxy": "^3.0.0",
     "prop-types": "15.8.1",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4669,10 +4669,10 @@ cozy-stack-client@^57.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^123.2.0:
-  version "123.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-123.2.0.tgz#e94e2e011c7dcc79f2198eabb1e429c85122e808"
-  integrity sha512-lSV06kRPq3ykjvgRGA90Hpbz7iIw2buyxRga6rMpa6zBlDPy4Yq5m2+DI4U9ul8RdWEVFcJ3/ah7cs8BdHg+hQ==
+cozy-ui@^124.2.0:
+  version "124.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-124.2.0.tgz#87956859f1d8aa31cd3aaffb96b67cddea7fb4b9"
+  integrity sha512-T0Jj0Jx7bTqwRU2AHNzPhGntu+/0hFUid0lIIjHaCOVZIKWBOrg18TQLc+k5IdFZRctSHfFgeolkp3U38ArDJw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"
@@ -4698,6 +4698,7 @@ cozy-ui@^123.2.0:
     react-remove-scroll "^2.4.0"
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
+    react-virtuoso "4.12.7"
     rooks "^5.11.2"
 
 create-ecdh@^4.0.4:
@@ -8646,9 +8647,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -9985,6 +9986,11 @@ react-use-measure@^2.0.0:
   integrity sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==
   dependencies:
     debounce "^1.2.1"
+
+react-virtuoso@4.12.7:
+  version "4.12.7"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.12.7.tgz#300f2585c61d213d4d422420f0d43ffc9674e6f5"
+  integrity sha512-njJp764he6Fi1p89PUW0k2kbyWu9w/y+MwdxmwK2kvdwwzVDbz2c2wMj5xdSruBFVgFTsI7Z85hxZR7aSHBrbQ==
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Upgrade cozy-ui dependency from previous version to 124.2.0 This includes updated components and styling improvements.