### PR TITLE
feat: Upgrade fixed cozy-dataproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "classnames": "2.3.1",
     "cozy-bar": "^23.1.0",
     "cozy-client": "^60.8.0",
-    "cozy-dataproxy-lib": "^4.9.0",
+    "cozy-dataproxy-lib": "^4.11.0",
     "cozy-device-helper": "^3.8.0",
     "cozy-devtools": "^1.3.0",
     "cozy-doctypes": "^1.97.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,10 +4503,10 @@ cozy-client@^60.8.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.9.0.tgz#622eed2782438c36eb1c50a3c263db4c12bd3026"
-  integrity sha512-KHz7RLXxSVvB3z9Ix6zh9nKy7GBULJFGabWCRDzTjrc/nGNahSBuyANDN1w+8u2OHJLJvGJc+xaTWPZ8CrayXg==
+cozy-dataproxy-lib@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.11.0.tgz#89cd935486517574ce1e648aab62209638afa4ab"
+  integrity sha512-4XMP8axtvpOnwlmBHug8obGCt5zU/gXABt4RLqCLi4FlsVryAGw9QYZibUPNsirGrHiMdwXrC5rrDPWAFMUUvA==
   dependencies:
     comlink "4.4.1"
     flexsearch "0.7.43"


### PR DESCRIPTION
The upgrade in db883c7fd133462225f1edd7a1beb932d3650688 had an issues making infinite loop. After fixing the issue in
cozy/cozy-libs#2829, we can now upgrade it again