### PR TITLE
feat(migration): Add nextcloud cleanup flow

### DIFF
--- a/src/components/Migration/Migration.jsx
+++ b/src/components/Migration/Migration.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 import { useI18n } from 'twake-i18n'
 
 import { useInstanceInfo, useQuery, isQueryLoading } from 'cozy-client'
@@ -164,14 +164,7 @@ const Migration = () => {
   const isNextcloudMigrated = Boolean(completedMigration)
   const completedMigrationId = completedMigration?._id ?? null
 
-  const {
-    clean,
-    isCleaning,
-    cleanSuccess,
-    cleanError,
-    setCleanSuccess,
-    setCleanError
-  } = useMigration({
+  const { clean, isCleaning } = useMigration({
     migrationId: completedMigrationId
   })
 
@@ -183,32 +176,28 @@ const Migration = () => {
     setShowCleanConfirmDialog(false)
     setCleaningDialogDismissed(false)
     if (isCleaning) return
-    await clean()
-  }, [isCleaning, clean])
 
-  useEffect(() => {
-    if (!cleanSuccess) return
+    const { success, error } = await clean()
 
-    showAlert({
-      title: t('MigrationView.cleanedSnackbar.title'),
-      message: t('MigrationView.cleanedSnackbar.description'),
-      severity: 'success',
-      duration: SNACKBAR_AUTO_HIDE_MS
-    })
-    setCleanSuccess(false)
-  }, [cleanSuccess, setCleanSuccess, showAlert, t])
+    if (success) {
+      showAlert({
+        title: t('MigrationView.cleanedSnackbar.title'),
+        message: t('MigrationView.cleanedSnackbar.description'),
+        severity: 'success',
+        duration: SNACKBAR_AUTO_HIDE_MS
+      })
+      return
+    }
 
-  useEffect(() => {
-    if (!cleanError) return
-
-    showAlert({
-      title: t('MigrationView.cleanErrorSnackbar.title'),
-      message: t('MigrationView.cleanErrorSnackbar.description'),
-      severity: 'error',
-      duration: SNACKBAR_AUTO_HIDE_MS
-    })
-    setCleanError(null)
-  }, [cleanError, setCleanError, showAlert, t])
+    if (error) {
+      showAlert({
+        title: t('MigrationView.cleanErrorSnackbar.title'),
+        message: t('MigrationView.cleanErrorSnackbar.description'),
+        severity: 'error',
+        duration: SNACKBAR_AUTO_HIDE_MS
+      })
+    }
+  }, [isCleaning, clean, showAlert, t])
 
   return (
     <DumbMigration

--- a/src/components/Migration/Migration.jsx
+++ b/src/components/Migration/Migration.jsx
@@ -1,13 +1,7 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { useI18n } from 'twake-i18n'
 
-import {
-  useInstanceInfo,
-  useQuery,
-  isQueryLoading,
-  useClient
-} from 'cozy-client'
-import flag from 'cozy-flags'
+import { useInstanceInfo, useQuery, isQueryLoading } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Chip from 'cozy-ui/transpiled/react/Chips'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -20,31 +14,32 @@ import ListItemSecondaryAction from 'cozy-ui/transpiled/react/ListItemSecondaryA
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Paper from 'cozy-ui/transpiled/react/Paper'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 
 import nextcloudLogo from '@/assets/icons/nextcloud-logo.svg'
-import NextcloudMigrationDialog from '@/components/Migration/NextcloudMigrationDialog'
-import {
-  resetNextcloudMigrationForTests,
-  RESET_NEXTCLOUD_MIGRATION_FLAG
-} from '@/components/Migration/resetNextcloudMigration'
+import { NextcloudCleanConfirmDialog } from '@/components/Migration/NextcloudCleanConfirmDialog'
+import { NextcloudCleaningDialog } from '@/components/Migration/NextcloudCleaningDialog'
+import { NextcloudMigrationDialog } from '@/components/Migration/NextcloudMigrationDialog'
+import useMigration from '@/components/Migration/useMigration'
 import Page from '@/components/Page'
 import PageTitle from '@/components/PageTitle'
-import logger from '@/lib/logger'
 import { buildCompletedNextcloudMigrationsQuery } from '@/lib/queries'
 
-const completedMigrationsQuery = buildCompletedNextcloudMigrationsQuery()
-
-const ProviderLogo = ({ icon, alt }) => (
-  <Icon icon={icon} aria-label={alt} size={40} />
-)
+const SNACKBAR_AUTO_HIDE_MS = 6000
 
 const DumbMigration = ({
   helpLink,
-  hasCompletedNextcloudMigration,
-  isCleaningNextcloud,
+  isNextcloudMigrated,
+  isCleaning,
   showNextcloudDialog,
-  onCleanNextcloud,
-  onShowNextcloudDialog
+  showCleanConfirmDialog,
+  showCleaningDialog,
+  onStartMigration,
+  onRequestClean,
+  onCancelClean,
+  onConfirmClean,
+  onCloseNextcloudDialog,
+  onDismissCleaningDialog
 }) => {
   const { t } = useI18n()
 
@@ -72,16 +67,17 @@ const DumbMigration = ({
         <List disablePadding>
           <ListItem>
             <ListItemIcon>
-              <ProviderLogo
+              <Icon
                 icon={nextcloudLogo}
-                alt={t('MigrationView.nextcloud.name')}
+                aria-label={t('MigrationView.nextcloud.name')}
+                size={40}
               />
             </ListItemIcon>
             <ListItemText
               primary={
                 <span className="u-flex u-flex-items-center">
                   {t('MigrationView.nextcloud.name')}
-                  {hasCompletedNextcloudMigration && (
+                  {isNextcloudMigrated && (
                     <Chip
                       label={t('MigrationView.migrated')}
                       color="success"
@@ -95,7 +91,7 @@ const DumbMigration = ({
               secondary={t('MigrationView.nextcloud.description')}
             />
             <ListItemSecondaryAction>
-              {hasCompletedNextcloudMigration ? (
+              {isNextcloudMigrated ? (
                 <Button
                   variant="text"
                   label={t('MigrationView.cleanNextcloud')}
@@ -103,8 +99,8 @@ const DumbMigration = ({
                   className="u-m-1"
                   startIcon={<Icon icon={DeleteIcon} size={14} />}
                   color="error"
-                  onClick={onCleanNextcloud}
-                  disabled={isCleaningNextcloud}
+                  onClick={onRequestClean}
+                  disabled={isCleaning}
                 />
               ) : (
                 <Button
@@ -112,7 +108,7 @@ const DumbMigration = ({
                   label={t('MigrationView.startMigration')}
                   size="small"
                   className="u-m-1"
-                  onClick={() => onShowNextcloudDialog(true)}
+                  onClick={onStartMigration}
                 />
               )}
             </ListItemSecondaryAction>
@@ -121,9 +117,19 @@ const DumbMigration = ({
       </Paper>
 
       {showNextcloudDialog && (
-        <NextcloudMigrationDialog
-          onCloseAll={() => onShowNextcloudDialog(false)}
+        <NextcloudMigrationDialog onCloseAll={onCloseNextcloudDialog} />
+      )}
+
+      {showCleanConfirmDialog && (
+        <NextcloudCleanConfirmDialog
+          isCleaning={isCleaning}
+          onCancel={onCancelClean}
+          onConfirm={onConfirmClean}
         />
+      )}
+
+      {showCleaningDialog && (
+        <NextcloudCleaningDialog onClose={onDismissCleaningDialog} />
       )}
 
       <Typography variant="h6" className="u-mb-half">
@@ -140,47 +146,84 @@ const DumbMigration = ({
 }
 
 const Migration = () => {
-  const client = useClient()
-  const [showNextcloudDialog, setShowNextcloudDialog] = useState(false)
-  const [isCleaningNextcloud, setIsCleaningNextcloud] = useState(false)
-
+  const { t } = useI18n()
+  const { showAlert } = useAlert()
   const { context } = useInstanceInfo()
   const helpLink = context?.data?.help_link || 'https://twake.app/en/support/'
 
+  const completedMigrationsQuery = buildCompletedNextcloudMigrationsQuery()
   const { data: completedMigrations, ...completedMigrationsQueryState } =
     useQuery(
       completedMigrationsQuery.definition,
       completedMigrationsQuery.options
     )
-  const hasCompletedNextcloudMigration =
-    !isQueryLoading(completedMigrationsQueryState) &&
-    (completedMigrations?.length ?? 0) > 0
 
-  const handleCleanNextcloud = useCallback(async () => {
-    if (!flag(RESET_NEXTCLOUD_MIGRATION_FLAG) || isCleaningNextcloud) return
+  const completedMigration = isQueryLoading(completedMigrationsQueryState)
+    ? null
+    : (completedMigrations?.[0] ?? null)
+  const isNextcloudMigrated = Boolean(completedMigration)
+  const completedMigrationId = completedMigration?._id ?? null
 
-    setIsCleaningNextcloud(true)
+  const {
+    clean,
+    isCleaning,
+    cleanSuccess,
+    cleanError,
+    setCleanSuccess,
+    setCleanError
+  } = useMigration({
+    migrationId: completedMigrationId
+  })
 
-    try {
-      await resetNextcloudMigrationForTests({
-        client,
-        completedMigrationsQuery
-      })
-    } catch (error) {
-      logger.error('Failed to reset Nextcloud migration for tests', error)
-    } finally {
-      setIsCleaningNextcloud(false)
-    }
-  }, [client, isCleaningNextcloud])
+  const [showNextcloudDialog, setShowNextcloudDialog] = useState(false)
+  const [showCleanConfirmDialog, setShowCleanConfirmDialog] = useState(false)
+  const [cleaningDialogDismissed, setCleaningDialogDismissed] = useState(false)
+
+  const handleConfirmClean = useCallback(async () => {
+    setShowCleanConfirmDialog(false)
+    setCleaningDialogDismissed(false)
+    if (isCleaning) return
+    await clean()
+  }, [isCleaning, clean])
+
+  useEffect(() => {
+    if (!cleanSuccess) return
+
+    showAlert({
+      title: t('MigrationView.cleanedSnackbar.title'),
+      message: t('MigrationView.cleanedSnackbar.description'),
+      severity: 'success',
+      duration: SNACKBAR_AUTO_HIDE_MS
+    })
+    setCleanSuccess(false)
+  }, [cleanSuccess, setCleanSuccess, showAlert, t])
+
+  useEffect(() => {
+    if (!cleanError) return
+
+    showAlert({
+      title: t('MigrationView.cleanErrorSnackbar.title'),
+      message: t('MigrationView.cleanErrorSnackbar.description'),
+      severity: 'error',
+      duration: SNACKBAR_AUTO_HIDE_MS
+    })
+    setCleanError(null)
+  }, [cleanError, setCleanError, showAlert, t])
 
   return (
     <DumbMigration
       helpLink={helpLink}
-      hasCompletedNextcloudMigration={hasCompletedNextcloudMigration}
-      isCleaningNextcloud={isCleaningNextcloud}
+      isNextcloudMigrated={isNextcloudMigrated}
+      isCleaning={isCleaning}
       showNextcloudDialog={showNextcloudDialog}
-      onCleanNextcloud={handleCleanNextcloud}
-      onShowNextcloudDialog={setShowNextcloudDialog}
+      showCleanConfirmDialog={showCleanConfirmDialog}
+      showCleaningDialog={isCleaning && !cleaningDialogDismissed}
+      onStartMigration={() => setShowNextcloudDialog(true)}
+      onRequestClean={() => setShowCleanConfirmDialog(true)}
+      onCancelClean={() => setShowCleanConfirmDialog(false)}
+      onConfirmClean={handleConfirmClean}
+      onCloseNextcloudDialog={() => setShowNextcloudDialog(false)}
+      onDismissCleaningDialog={() => setCleaningDialogDismissed(true)}
     />
   )
 }

--- a/src/components/Migration/NextcloudCleanConfirmDialog.jsx
+++ b/src/components/Migration/NextcloudCleanConfirmDialog.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import DeleteIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import nextcloudLogo from '@/assets/icons/nextcloud-logo.svg'
+
+const NextcloudCleanConfirmDialog = ({ isCleaning, onCancel, onConfirm }) => {
+  const { t } = useI18n()
+
+  return (
+    <ConfirmDialog
+      open
+      title={
+        <span className="u-flex u-flex-items-center u-column-gap-half">
+          <Icon icon={nextcloudLogo} size={24} className="u-mr-1" />
+          {t('MigrationView.cleanNextcloudDialog.title')}
+        </span>
+      }
+      content={
+        <>
+          <Typography variant="body2" className="u-mb-1">
+            {t('MigrationView.cleanNextcloudDialog.description')}
+          </Typography>
+          <Typography variant="body2" className="u-mb-half">
+            {t('MigrationView.cleanNextcloudDialog.disclaimer1')}
+          </Typography>
+          <Typography variant="body2">
+            {t('MigrationView.cleanNextcloudDialog.disclaimer2')}
+          </Typography>
+        </>
+      }
+      actions={
+        <>
+          <Button
+            label={t('MigrationView.cleanNextcloudDialog.cancel')}
+            variant="secondary"
+            className="u-fz-small"
+            onClick={onCancel}
+          />
+          <Button
+            label={t('MigrationView.cleanNextcloudDialog.confirm')}
+            color="error"
+            className="u-fz-small"
+            startIcon={<Icon icon={DeleteIcon} size={14} />}
+            onClick={onConfirm}
+            disabled={isCleaning}
+          />
+        </>
+      }
+      onClose={onCancel}
+    />
+  )
+}
+
+export { NextcloudCleanConfirmDialog }

--- a/src/components/Migration/NextcloudCleaningDialog.jsx
+++ b/src/components/Migration/NextcloudCleaningDialog.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import LinearProgress from 'cozy-ui/transpiled/react/LinearProgress'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import nextcloudLogo from '@/assets/icons/nextcloud-logo.svg'
+
+const NextcloudCleaningDialog = ({ onClose }) => {
+  const { t } = useI18n()
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={
+        <span className="u-flex u-flex-items-center u-column-gap-half">
+          <Icon icon={nextcloudLogo} size={24} className="u-mr-1" />
+          {t('MigrationView.cleaningNextcloudDialog.title')}
+        </span>
+      }
+      content={
+        <>
+          <Typography variant="body2" className="u-mb-1">
+            {t('MigrationView.cleaningNextcloudDialog.description')}
+          </Typography>
+          <LinearProgress />
+        </>
+      }
+    />
+  )
+}
+
+export { NextcloudCleaningDialog }

--- a/src/components/Migration/NextcloudCleaningDialog.spec.jsx
+++ b/src/components/Migration/NextcloudCleaningDialog.spec.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { NextcloudCleaningDialog } from './NextcloudCleaningDialog'
+import AppLike from 'test/AppLike'
+
+jest.mock('@/assets/icons/nextcloud-logo.svg', () => 'nextcloud-logo.svg')
+
+const setup = (props = {}) =>
+  render(
+    <AppLike>
+      <NextcloudCleaningDialog onClose={jest.fn()} {...props} />
+    </AppLike>
+  )
+
+describe('NextcloudCleaningDialog', () => {
+  it('shows the cleaning title', () => {
+    setup()
+    expect(screen.queryByText('Cleaning Nextcloud Drive')).toBeInTheDocument()
+  })
+
+  it('shows the cleaning description', () => {
+    setup()
+    expect(
+      screen.queryByText(
+        'Permanently deleting all data from your Nextcloud Drive…'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows a progress bar', () => {
+    setup()
+    expect(screen.queryByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('accepts an onClose prop without crashing', () => {
+    const onClose = jest.fn()
+    expect(() => setup({ onClose })).not.toThrow()
+  })
+})

--- a/src/components/Migration/NextcloudMigrationDialog.jsx
+++ b/src/components/Migration/NextcloudMigrationDialog.jsx
@@ -109,4 +109,4 @@ const NextcloudMigrationDialog = ({ onCloseAll }) => {
   )
 }
 
-export default NextcloudMigrationDialog
+export { NextcloudMigrationDialog }

--- a/src/components/Migration/useMigration.js
+++ b/src/components/Migration/useMigration.js
@@ -5,6 +5,8 @@ import { useClient, generateWebLink } from 'cozy-client'
 import useMigrationMock from './useMigrationMock'
 import { NEXTCLOUD_MIGRATIONS_DOCTYPE } from '../../doctypes'
 
+import logger from '@/lib/logger'
+
 export const NEXTCLOUD_IMPORTED_FILES_DIR_NAME = '/Nextcloud imported files'
 
 export const computeRemainingSeconds = (progress, startedAt) => {
@@ -81,6 +83,10 @@ const useMigration = ({
 
   const client = useClient()
   const [migrationId, setMigrationId] = useState(externalId)
+
+  useEffect(() => {
+    setMigrationId(externalId)
+  }, [externalId])
   const [startedAt, setStartedAt] = useState(externalStartedAt)
   const [progress, setProgress] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -88,6 +94,9 @@ const useMigration = ({
   const [cancelSuccess, setCancelSuccess] = useState(false)
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
+  const [isCleaning, setIsCleaning] = useState(false)
+  const [cleanSuccess, setCleanSuccess] = useState(false)
+  const [cleanError, setCleanError] = useState(null)
 
   const start = useCallback(
     async (credentials = {}) => {
@@ -128,6 +137,26 @@ const useMigration = ({
     }
   }, [client, migrationId])
 
+  const clean = useCallback(async () => {
+    if (!migrationId) return
+    setIsCleaning(true)
+    setCleanError(null)
+    try {
+      await client
+        .getStackClient()
+        .fetchJSON(
+          'POST',
+          `/remote/nextcloud/migration/${migrationId}/delete-source`
+        )
+      setCleanSuccess(true)
+    } catch (err) {
+      logger.error('Failed to clean Nextcloud', err)
+      setCleanError('clean_error')
+    } finally {
+      setIsCleaning(false)
+    }
+  }, [client, migrationId])
+
   useEffect(() => {
     if (!migrationId) return
 
@@ -158,12 +187,18 @@ const useMigration = ({
   return {
     start,
     cancel,
+    clean,
     migrationId,
     startedAt,
     progress,
     isLoading,
     isCanceling,
     cancelSuccess,
+    isCleaning,
+    cleanSuccess,
+    cleanError,
+    setCleanSuccess,
+    setCleanError,
     error,
     setError,
     status

--- a/src/components/Migration/useMigration.js
+++ b/src/components/Migration/useMigration.js
@@ -95,8 +95,6 @@ const useMigration = ({
   const [error, setError] = useState(null)
   const [status, setStatus] = useState(null)
   const [isCleaning, setIsCleaning] = useState(false)
-  const [cleanSuccess, setCleanSuccess] = useState(false)
-  const [cleanError, setCleanError] = useState(null)
 
   const start = useCallback(
     async (credentials = {}) => {
@@ -138,9 +136,9 @@ const useMigration = ({
   }, [client, migrationId])
 
   const clean = useCallback(async () => {
-    if (!migrationId) return
+    if (!migrationId) return { success: false, error: null }
+
     setIsCleaning(true)
-    setCleanError(null)
     try {
       await client
         .getStackClient()
@@ -148,10 +146,10 @@ const useMigration = ({
           'POST',
           `/remote/nextcloud/migration/${migrationId}/delete-source`
         )
-      setCleanSuccess(true)
+      return { success: true, error: null }
     } catch (err) {
       logger.error('Failed to clean Nextcloud', err)
-      setCleanError('clean_error')
+      return { success: false, error: 'clean_error' }
     } finally {
       setIsCleaning(false)
     }
@@ -195,10 +193,6 @@ const useMigration = ({
     isCanceling,
     cancelSuccess,
     isCleaning,
-    cleanSuccess,
-    cleanError,
-    setCleanSuccess,
-    setCleanError,
     error,
     setError,
     status

--- a/src/components/Migration/useMigration.spec.js
+++ b/src/components/Migration/useMigration.spec.js
@@ -1,12 +1,26 @@
 import { renderHook, act } from '@testing-library/react'
 
-import { generateWebLink } from 'cozy-client'
+import { generateWebLink, useClient } from 'cozy-client'
 
 import { computeRemainingSeconds, useDriveUrl } from './useMigration'
+import useMigration from './useMigration'
 
 jest.mock('cozy-client', () => ({
-  generateWebLink: jest.fn(() => 'https://drive.example.com')
+  generateWebLink: jest.fn(() => 'https://drive.example.com'),
+  useClient: jest.fn()
 }))
+
+jest.mock('@/lib/logger', () => ({ error: jest.fn() }))
+
+const buildMockClient = ({ fetchJSON } = {}) => ({
+  plugins: {
+    realtime: {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn()
+    }
+  },
+  getStackClient: () => ({ fetchJSON: fetchJSON || jest.fn() })
+})
 
 describe('computeRemainingSeconds', () => {
   const baseProgress = {
@@ -129,5 +143,73 @@ describe('useDriveUrl', () => {
     await act(async () => rerender({ isDone: true }))
 
     expect(statByPath).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useMigration — clean', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls POST delete-source with the migrationId', async () => {
+    const fetchJSON = jest.fn().mockResolvedValue({})
+    useClient.mockReturnValue(buildMockClient({ fetchJSON }))
+
+    const { result } = renderHook(() =>
+      useMigration({ migrationId: 'migration-42' })
+    )
+
+    await act(async () => {
+      await result.current.clean()
+    })
+
+    expect(fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/remote/nextcloud/migration/migration-42/delete-source'
+    )
+  })
+
+  it('sets cleanSuccess to true on success', async () => {
+    const fetchJSON = jest.fn().mockResolvedValue({})
+    useClient.mockReturnValue(buildMockClient({ fetchJSON }))
+
+    const { result } = renderHook(() =>
+      useMigration({ migrationId: 'migration-42' })
+    )
+
+    await act(async () => {
+      await result.current.clean()
+    })
+
+    expect(result.current.cleanSuccess).toBe(true)
+  })
+
+  it('sets cleanError and does not set cleanSuccess on failure', async () => {
+    const fetchJSON = jest.fn().mockRejectedValue(new Error('server error'))
+    useClient.mockReturnValue(buildMockClient({ fetchJSON }))
+
+    const { result } = renderHook(() =>
+      useMigration({ migrationId: 'migration-42' })
+    )
+
+    await act(async () => {
+      await result.current.clean()
+    })
+
+    expect(result.current.cleanSuccess).toBe(false)
+    expect(result.current.cleanError).toBe('clean_error')
+  })
+
+  it('does nothing when migrationId is null', async () => {
+    const fetchJSON = jest.fn()
+    useClient.mockReturnValue(buildMockClient({ fetchJSON }))
+
+    const { result } = renderHook(() => useMigration())
+
+    await act(async () => {
+      await result.current.clean()
+    })
+
+    expect(fetchJSON).not.toHaveBeenCalled()
   })
 })

--- a/src/components/Migration/useMigration.spec.js
+++ b/src/components/Migration/useMigration.spec.js
@@ -169,7 +169,7 @@ describe('useMigration — clean', () => {
     )
   })
 
-  it('sets cleanSuccess to true on success', async () => {
+  it('returns success after cleaning succeeds', async () => {
     const fetchJSON = jest.fn().mockResolvedValue({})
     useClient.mockReturnValue(buildMockClient({ fetchJSON }))
 
@@ -177,14 +177,15 @@ describe('useMigration — clean', () => {
       useMigration({ migrationId: 'migration-42' })
     )
 
+    let cleanResult
     await act(async () => {
-      await result.current.clean()
+      cleanResult = await result.current.clean()
     })
 
-    expect(result.current.cleanSuccess).toBe(true)
+    expect(cleanResult).toEqual({ success: true, error: null })
   })
 
-  it('sets cleanError and does not set cleanSuccess on failure', async () => {
+  it('returns clean_error after cleaning fails', async () => {
     const fetchJSON = jest.fn().mockRejectedValue(new Error('server error'))
     useClient.mockReturnValue(buildMockClient({ fetchJSON }))
 
@@ -192,12 +193,12 @@ describe('useMigration — clean', () => {
       useMigration({ migrationId: 'migration-42' })
     )
 
+    let cleanResult
     await act(async () => {
-      await result.current.clean()
+      cleanResult = await result.current.clean()
     })
 
-    expect(result.current.cleanSuccess).toBe(false)
-    expect(result.current.cleanError).toBe('clean_error')
+    expect(cleanResult).toEqual({ success: false, error: 'clean_error' })
   })
 
   it('does nothing when migrationId is null', async () => {
@@ -206,10 +207,12 @@ describe('useMigration — clean', () => {
 
     const { result } = renderHook(() => useMigration())
 
+    let cleanResult
     await act(async () => {
-      await result.current.clean()
+      cleanResult = await result.current.clean()
     })
 
+    expect(cleanResult).toEqual({ success: false, error: null })
     expect(fetchJSON).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -12,6 +12,5 @@ export const initFlags = () => {
     flag('settings.specify-blocking-subscription-vendor-dev')
     flag('settings.2fa.enabled')
     flag('settings.delete-user-from-signup-admin-api')
-    flag('settings.reset-for-migration.enabled')
   }
 }

--- a/src/lib/queries.js
+++ b/src/lib/queries.js
@@ -92,8 +92,9 @@ export const buildRunningMigrationQuery = () => ({
 export const buildCompletedNextcloudMigrationsQuery = () => ({
   definition: Q(NEXTCLOUD_MIGRATIONS_DOCTYPE)
     .where({ status: 'completed' })
-    .limitBy(1)
-    .indexFields(['status']),
+    .partialIndex({ source_deleted_at: { $exists: false } })
+    .indexFields(['status'])
+    .limitBy(1),
   options: {
     as: `${NEXTCLOUD_MIGRATIONS_DOCTYPE}/completed`
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -629,6 +629,26 @@
     "startMigration": "Start migration",
     "migrated": "Migrated",
     "cleanNextcloud": "Clean Nextcloud",
+    "cleanNextcloudDialog": {
+      "title": "Clean Nextcloud Drive",
+      "description": "You are about to permanently delete all data stored in your Nextcloud Drive.",
+      "disclaimer1": "This action only affects data on the Nextcloud side.",
+      "disclaimer2": "No data will be deleted from Twake or any of our other connected services.",
+      "confirm": "Clean Nextcloud",
+      "cancel": "Cancel"
+    },
+    "cleaningNextcloudDialog": {
+      "title": "Cleaning Nextcloud Drive",
+      "description": "Permanently deleting all data from your Nextcloud Drive…"
+    },
+    "cleanedSnackbar": {
+      "title": "Nextcloud drive cleaned",
+      "description": "All data has been permanently removed from your Nextcloud drive."
+    },
+    "cleanErrorSnackbar": {
+      "title": "Nextcloud drive could not be cleaned",
+      "description": "Please try again or contact support."
+    },
     "nextcloud": {
       "name": "Nextcloud",
       "description": "Your files, folders and documents will be copied to your Twake.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -627,6 +627,26 @@
     "startMigration": "Démarrer la migration",
     "migrated": "Migré",
     "cleanNextcloud": "Nettoyer Nextcloud",
+    "cleanNextcloudDialog": {
+      "title": "Nettoyer Nextcloud Drive",
+      "description": "Vous êtes sur le point de supprimer définitivement toutes les données stockées dans votre Nextcloud Drive.",
+      "disclaimer1": "Cette action n'affecte que les données côté Nextcloud.",
+      "disclaimer2": "Aucune donnée ne sera supprimée de Twake ou de nos autres services connectés.",
+      "confirm": "Nettoyer Nextcloud",
+      "cancel": "Annuler"
+    },
+    "cleaningNextcloudDialog": {
+      "title": "Nettoyage de Nextcloud Drive",
+      "description": "Suppression définitive de toutes les données de votre Nextcloud Drive…"
+    },
+    "cleanedSnackbar": {
+      "title": "Nextcloud Drive nettoyé",
+      "description": "Toutes les données ont été définitivement supprimées de votre Nextcloud Drive."
+    },
+    "cleanErrorSnackbar": {
+      "title": "Impossible de nettoyer Nextcloud Drive",
+      "description": "Veuillez réessayer ou contacter le support."
+    },
     "nextcloud": {
       "name": "Nextcloud",
       "description": "Vos fichiers, dossiers et documents seront copiés dans votre Twake.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -580,6 +580,26 @@
     "startMigration": "Начать миграцию",
     "migrated": "Миграция завершена",
     "cleanNextcloud": "Очистить Nextcloud",
+    "cleanNextcloudDialog": {
+      "title": "Очистить Nextcloud Drive",
+      "description": "Вы собираетесь безвозвратно удалить все данные, хранящиеся в вашем Nextcloud Drive.",
+      "disclaimer1": "Это действие затрагивает только данные на стороне Nextcloud.",
+      "disclaimer2": "Никакие данные не будут удалены из Twake или других подключённых сервисов.",
+      "confirm": "Очистить Nextcloud",
+      "cancel": "Отмена"
+    },
+    "cleaningNextcloudDialog": {
+      "title": "Очистка Nextcloud Drive",
+      "description": "Безвозвратное удаление всех данных из вашего Nextcloud Drive…"
+    },
+    "cleanedSnackbar": {
+      "title": "Nextcloud Drive очищен",
+      "description": "Все данные были безвозвратно удалены из вашего Nextcloud Drive."
+    },
+    "cleanErrorSnackbar": {
+      "title": "Не удалось очистить Nextcloud Drive",
+      "description": "Пожалуйста, попробуйте снова или обратитесь в поддержку."
+    },
     "nextcloud": {
       "name": "Nextcloud",
       "description": "Ваши файлы, папки и документы будут скопированы в ваш Twake.",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -582,6 +582,26 @@
     "startMigration": "Bắt đầu di chuyển",
     "migrated": "Đã di chuyển",
     "cleanNextcloud": "Dọn dẹp Nextcloud",
+    "cleanNextcloudDialog": {
+      "title": "Dọn dẹp Nextcloud Drive",
+      "description": "Bạn sắp xóa vĩnh viễn tất cả dữ liệu được lưu trữ trong Nextcloud Drive của bạn.",
+      "disclaimer1": "Hành động này chỉ ảnh hưởng đến dữ liệu phía Nextcloud.",
+      "disclaimer2": "Không có dữ liệu nào bị xóa khỏi Twake hoặc các dịch vụ kết nối khác của chúng tôi.",
+      "confirm": "Dọn dẹp Nextcloud",
+      "cancel": "Hủy"
+    },
+    "cleaningNextcloudDialog": {
+      "title": "Đang dọn dẹp Nextcloud Drive",
+      "description": "Đang xóa vĩnh viễn tất cả dữ liệu khỏi Nextcloud Drive của bạn…"
+    },
+    "cleanedSnackbar": {
+      "title": "Đã dọn dẹp Nextcloud drive",
+      "description": "Tất cả dữ liệu đã được xóa vĩnh viễn khỏi Nextcloud drive của bạn."
+    },
+    "cleanErrorSnackbar": {
+      "title": "Không thể dọn dẹp Nextcloud drive",
+      "description": "Vui lòng thử lại hoặc liên hệ bộ phận hỗ trợ."
+    },
     "nextcloud": {
       "name": "Nextcloud",
       "description": "Các tệp, thư mục và tài liệu của bạn sẽ được sao chép sang Twake.",


### PR DESCRIPTION
Let migrated users remove data from their Nextcloud source/

Add confirmation and progress dialogs with localized feedback so users understand the deletion impact and result.

[Capture vidéo du 2026-05-04 09-54-23.webm](https://github.com/user-attachments/assets/66699d90-9d48-4002-b661-4698748fb372)

