### PR TITLE
feat(migration): Replace progress close button with hide button

### DIFF
--- a/src/components/Migration/NextcloudProgressDialog.jsx
+++ b/src/components/Migration/NextcloudProgressDialog.jsx
@@ -6,9 +6,8 @@ import { useClient } from 'cozy-client'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import Buttons from 'cozy-ui/transpiled/react/Buttons'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
+import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import Cross from 'cozy-ui/transpiled/react/Icons/Cross'
 import FolderOpen from 'cozy-ui/transpiled/react/Icons/FolderOpen'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
@@ -58,13 +57,14 @@ const NextcloudProgressDialog = ({
         style: { background: 'var(--defaultBackgroundColor, #fff)' }
       }}
     >
-      <IconButton
+      <DropdownButton
         onClick={onCloseAll}
+        color="textSecondary"
         className="u-top-xs u-right-xs"
         style={{ position: 'absolute' }}
       >
-        <Icon icon={Cross} size={16} />
-      </IconButton>
+        {t('MigrationView.nextcloud.progress.hide')}
+      </DropdownButton>
       <div
         className="u-flex u-flex-column u-flex-items-center u-ph-3"
         style={{ width: '100%', maxWidth: 560 }}

--- a/src/components/Migration/NextcloudProgressDialog.spec.jsx
+++ b/src/components/Migration/NextcloudProgressDialog.spec.jsx
@@ -147,10 +147,10 @@ describe('NextcloudProgressDialog', () => {
       expect(onCancel).toHaveBeenCalledTimes(1)
     })
 
-    it('calls onCloseAll when the close icon is clicked', () => {
+    it('calls onCloseAll when the hide button is clicked', () => {
       const onCloseAll = jest.fn()
       setup({ onCloseAll })
-      fireEvent.click(screen.getByRole('button', { name: '' }))
+      fireEvent.click(screen.getByRole('button', { name: /Hide/ }))
       expect(onCloseAll).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -679,6 +679,7 @@
         "timeSeconds_plural": "%{count} seconds",
         "timeMinutes": "~%{count} min",
         "timeMinutes_plural": "~%{count} min",
+        "hide": "Hide",
         "cancel": "Cancel transfer",
         "cancelSuccess": "Cancellation requested. The transfer will stop shortly.",
         "cancelError": "The cancellation could not be sent. Please try again."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -677,6 +677,7 @@
         "timeSeconds_plural": "%{count} secondes restantes",
         "timeMinutes": "~%{count} min restante",
         "timeMinutes_plural": "~%{count} min restantes",
+        "hide": "Masquer",
         "cancel": "Annuler le transfert",
         "cancelSuccess": "Annulation demandée. Le transfert va s'arrêter dans quelques instants.",
         "cancelError": "L'annulation n'a pas pu être envoyée. Veuillez réessayer."

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -630,6 +630,7 @@
         "timeSeconds_plural": "%{count} секунд",
         "timeMinutes": "~%{count} мин",
         "timeMinutes_plural": "~%{count} мин",
+        "hide": "Скрыть",
         "cancel": "Отменить перенос",
         "cancelSuccess": "Запрос на отмену отправлен. Перенос скоро остановится.",
         "cancelError": "Не удалось отправить отмену. Пожалуйста, попробуйте снова."

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -632,6 +632,7 @@
         "timeSeconds_plural": "%{count} giây",
         "timeMinutes": "~%{count} phút",
         "timeMinutes_plural": "~%{count} phút",
+        "hide": "Ẩn",
         "cancel": "Hủy truyền",
         "cancelSuccess": "Đã gửi yêu cầu hủy. Quá trình truyền sẽ dừng lại ngay sau đây.",
         "cancelError": "Không thể gửi yêu cầu hủy. Vui lòng thử lại."


### PR DESCRIPTION
Some users would else mistake it with "Cancel Migration"

<img width="605" height="426" alt="image" src="https://github.com/user-attachments/assets/6ac4d734-5de5-4e21-852c-ef7ae4e09b2d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Nextcloud migration progress dialog now includes a localized dropdown menu option to hide the progress panel, replacing the previous close button for improved accessibility and user control.

* **Localization**
  * Translations added for the hide function in English, French, Russian, and Vietnamese.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-settings/pull/833)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->