### PR TITLE
fix(settings): decouple credential management urls from signup.url

### DIFF
--- a/src/components/Profile/PasswordSection.jsx
+++ b/src/components/Profile/PasswordSection.jsx
@@ -13,10 +13,10 @@ const PasswordSection = () => {
   const { t } = useI18n()
   const { hasPassword } = useHasPassword()
 
-  const signUpUrl = flag('signup.url')
+  const passwordUrl = flag('settings.password.url')
   const isPasswordReadonly = flag('settings.password.readonly')
 
-  if (signUpUrl) {
+  if (passwordUrl) {
     return (
       <Stack spacing="m">
         <Typography variant="h5" gutterBottom>
@@ -29,7 +29,7 @@ const PasswordSection = () => {
           variant="secondary"
           size="medium"
           label={t('ProfileView.password.cta')}
-          href={`${signUpUrl}/change-password`}
+          href={passwordUrl}
           target="_blank"
           disabled={isPasswordReadonly}
         />

--- a/src/components/Profile/PasswordSection.spec.jsx
+++ b/src/components/Profile/PasswordSection.spec.jsx
@@ -21,12 +21,12 @@ describe('PasswordSection', () => {
 
   const setup = ({
     hasPassword,
-    signUpUrl = null,
+    passwordUrl = null,
     isPasswordReadonly = false
   }) => {
     useHasPassword.mockReturnValue({ hasPassword })
     flag.mockImplementation(flagName => {
-      if (flagName === 'signup.url') return signUpUrl
+      if (flagName === 'settings.password.url') return passwordUrl
       if (flagName === 'settings.password.readonly') return isPasswordReadonly
       return null
     })
@@ -37,9 +37,12 @@ describe('PasswordSection', () => {
     )
   }
 
-  describe('when signUpUrl flag is set', () => {
+  describe('when passwordUrl flag is set', () => {
     it('should render external link button', () => {
-      setup({ hasPassword: true, signUpUrl: 'https://example.com' })
+      setup({
+        hasPassword: true,
+        passwordUrl: 'https://example.com/change-password'
+      })
       const button = screen.getByText('Update my password')
       expect(button).toBeTruthy()
       expect(button.closest('a')).toHaveAttribute(
@@ -52,7 +55,7 @@ describe('PasswordSection', () => {
     it('should disable button when password is readonly', () => {
       setup({
         hasPassword: true,
-        signUpUrl: 'https://example.com',
+        passwordUrl: 'https://example.com/change-password',
         isPasswordReadonly: true
       })
       const button = screen.getByText('Update my password').closest('a')
@@ -60,7 +63,7 @@ describe('PasswordSection', () => {
     })
   })
 
-  describe('when signUpUrl flag is not set', () => {
+  describe('when passwordUrl flag is not set', () => {
     it('should render internal link button when user has password', () => {
       setup({ hasPassword: true })
       const button = screen.getByText('Update my password')

--- a/src/components/Profile/PhoneNumberSection.jsx
+++ b/src/components/Profile/PhoneNumberSection.jsx
@@ -20,8 +20,8 @@ const PhoneNumberSection = () => {
     instanceQuery.options
   )
 
-  const signUpUrl = flag('signup.url')
-  const isPhoneReadonly = flag('settings.phone.readonly') || !signUpUrl
+  const phoneUrl = flag('settings.phone.url')
+  const isPhoneReadonly = flag('settings.phone.readonly') || !phoneUrl
 
   return (
     <Stack spacing="m">
@@ -38,7 +38,7 @@ const PhoneNumberSection = () => {
         variant="secondary"
         size="medium"
         label={t('ProfileView.phone_number.change_button')}
-        href={`${signUpUrl}/change-phone`}
+        href={phoneUrl}
         target="_blank"
         disabled={isPhoneReadonly}
       />

--- a/src/components/Profile/ProfileView.jsx
+++ b/src/components/Profile/ProfileView.jsx
@@ -46,8 +46,8 @@ const ProfileView = ({
   const isPhoneEnabled = flag('settings.phone.enabled')
   const isDeleteEnabled = flag('settings.delete.enabled')
   const isEmailReadOnly = flag('settings.email.readonly')
-  const isSignupEnabled = flag('signup.url')
-  const ssoTwoFaUrl = flag('sso.portail.2fa-url')
+  const signupUrl = flag('signup.url')
+  const ssoTwoFaUrl = flag('settings.2fa.url')
 
   return (
     <>
@@ -68,10 +68,8 @@ const ProfileView = ({
           />
         )}
         {isPhoneEnabled && <PhoneNumberSection />}
-        {isTwoFAEnabled && isSignupEnabled && <TwoFA />}
-        {isTwoFAEnabled && !isSignupEnabled && ssoTwoFaUrl && (
-          <TwoFASSO url={ssoTwoFaUrl} />
-        )}
+        {isTwoFAEnabled && ssoTwoFaUrl && <TwoFASSO url={ssoTwoFaUrl} />}
+        {isTwoFAEnabled && !ssoTwoFaUrl && signupUrl && <TwoFA />}
         <PasswordSection />
         <LanguageSection />
         <DefaultRedirectionSection />


### PR DESCRIPTION
## Problem

- `signup.url` did two unrelated jobs: it was the base for credential management links (`${signup.url}/change-password`, `${signup.url}/change-phone`) and the gate for the 2FA section, while also being the SaaS signup/advertising URL.
- Those two meanings only match when the signup app is also the identity provider.
- On an instance backed by an external SSO you still want `signup.url` set to advertise the SaaS, but password, phone and 2FA must point at the SSO.
- With the old code, setting `signup.url` forced credential management to link to the signup app, sending users to the wrong place.

## Solution

- Password reads `settings.password.url` instead of deriving its link from `signup.url`.
- Phone reads `settings.phone.url`; the field stays read only when that flag is absent.
- 2FA selection is now SSO first: when `settings.2fa.url` is set it renders the SSO button, otherwise it falls back to `signup.url` for the signup-app component.
- These flags now hold the full destination URL rather than a base the app appends a path to.
- `signup.url` no longer drives any credential management, so it can be set purely to advertise the SaaS without side effects.

| Flag | Purpose | Drives |
| --- | --- | --- |
| `settings.password.url` | Full URL to the password change page | Password section link |
| `settings.phone.url` | Full URL to the phone change page | Phone section link, read-only state |
| `settings.2fa.url` | Full URL to the external SSO 2FA page | Renders the SSO 2FA component (takes precedence) |
| `signup.url` | SaaS signup / advertising URL | Fallback signup-app 2FA component only |
