### PR TITLE
fix: send support email on account deletion when no reason given

### DIFF
--- a/src/actions/email.js
+++ b/src/actions/email.js
@@ -70,8 +70,6 @@ export function sendMessageToSupport(client, message, t) {
 }
 
 export function sendDeleteAccountReasonEmail(client, subject, message) {
-  if (!message) return
-
   return sendEmail(
     client,
     CONTACT_RECIPIENT_LIST,
@@ -81,8 +79,6 @@ export function sendDeleteAccountReasonEmail(client, subject, message) {
 }
 
 export function sendDeleteAccountByEmailOnlyEmail(client, subject, message) {
-  if (!message) return
-
   return sendEmail(
     client,
     CONTACT_RECIPIENT_LIST,

--- a/src/actions/email.spec.js
+++ b/src/actions/email.spec.js
@@ -1,6 +1,10 @@
 import { createMockClient } from 'cozy-client/dist/mock'
 
-import { sendMessageToSupport } from './email'
+import {
+  sendMessageToSupport,
+  sendDeleteAccountReasonEmail,
+  sendDeleteAccountByEmailOnlyEmail
+} from './email'
 import { cozyFetch } from './index'
 import createStore from '../store'
 
@@ -26,6 +30,59 @@ describe('send email', () => {
     jest.spyOn(store, 'dispatch')
     return { store, client }
   }
+
+  const setupJobCollection = client => {
+    cozyFetch.mockResolvedValue({
+      data: {
+        attributes: {
+          state: 'done'
+        }
+      }
+    })
+
+    const mockJobCollection = {
+      create: jest.fn().mockResolvedValue({
+        data: { attributes: { _id: 'job-id-0' } }
+      })
+    }
+
+    client.collection = type => {
+      if (type === 'io.cozy.jobs') {
+        return mockJobCollection
+      } else {
+        throw new Error(`${type} collection is not mocked in email.spec.js`)
+      }
+    }
+
+    return mockJobCollection
+  }
+
+  const expectFallbackBody = mockJobCollection =>
+    expect(mockJobCollection.create).toHaveBeenCalledWith(
+      'sendmail',
+      expect.objectContaining({
+        parts: [{ type: 'text/plain', body: 'No reason/message provided.' }]
+      }),
+      expect.anything()
+    )
+
+  it('should send the delete account reason email with a fallback body when no reason is given', async () => {
+    const { client } = setup()
+    const mockJobCollection = setupJobCollection(client)
+
+    await sendDeleteAccountReasonEmail(client, 'subject', '')
+
+    expectFallbackBody(mockJobCollection)
+  })
+
+  it('should send the by-email-only deletion email with a fallback body when no reason is given', async () => {
+    const { client } = setup()
+    const mockJobCollection = setupJobCollection(client)
+
+    await sendDeleteAccountByEmailOnlyEmail(client, 'subject', '')
+
+    expectFallbackBody(mockJobCollection)
+  })
 
   it('should send an email and wait for completion', async () => {
     const { store, client } = setup()


### PR DESCRIPTION
## Problem
When deleting an account, the request to support was only emailed if the user typed a reason. Leaving the reason blank silently skipped the email, so support never learned about the deletion even though the deletion request itself still went through.

## Solution
Drop the early `if (!message) return` guard from the two delete-account email senders. The email body already falls back to "No reason/message provided." for an empty reason, so the email is now always sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account-deletion email requests now proceed even when no reason/message is entered, ensuring an email is still sent with a default body.
  * Improved reliability of the delete-account email workflow when the message field is empty.
* **Tests**
  * Added coverage to confirm delete-account email requests use the expected fallback content when the reason is blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->